### PR TITLE
Add AssetSentimentDao and unit tests

### DIFF
--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDaoTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDaoTest.java
@@ -1,0 +1,71 @@
+package com.google.moviestvsentiments.service.assetSentiment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import android.content.Context;
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.room.Room;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.google.moviestvsentiments.model.Asset;
+import com.google.moviestvsentiments.model.AssetType;
+import com.google.moviestvsentiments.service.database.SentimentsDatabase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class AssetSentimentDaoTest {
+
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    private AssetSentimentDao assetSentimentDao;
+    private SentimentsDatabase database;
+
+    @Before
+    public void createDatabase() {
+        Context context = ApplicationProvider.getApplicationContext();
+        database = Room.inMemoryDatabaseBuilder(context, SentimentsDatabase.class)
+                .allowMainThreadQueries().build();
+        assetSentimentDao = database.assetSentimentDao();
+    }
+
+    @After
+    public void closeDatabase() {
+        database.close();
+    }
+
+    @Test
+    public void addAndGetAsset_withIncorrectId_returnsNull() {
+        Asset asset = new Asset("assetId", AssetType.MOVIE, "assetTitle", "posterURL",
+                "bannerURL", "plotDescription", "runtime", "year",
+                1, "imdbRating", "rtRating");
+        assetSentimentDao.addAsset(asset);
+        asset = assetSentimentDao.getAsset("incorrectId", AssetType.MOVIE);
+        assertNull(asset);
+    }
+
+    @Test
+    public void addAndGetAsset_withIncorrectType_returnsNull() {
+        Asset asset = new Asset("assetId", AssetType.MOVIE, "assetTitle", "posterURL",
+                "bannerURL", "plotDescription", "runtime", "year",
+                1,"imdbRating", "rtRating");
+        assetSentimentDao.addAsset(asset);
+        asset = assetSentimentDao.getAsset("assetId", AssetType.SHOW);
+        assertNull(asset);
+    }
+
+    @Test
+    public void addAndGetAsset_returnsAsset() {
+        Asset asset = new Asset("assetId", AssetType.MOVIE, "assetTitle", "posterURL",
+                "bannerURL", "plotDescription", "runtime", "year",
+                1,"imdbRating", "rtRating");
+        assetSentimentDao.addAsset(asset);
+        Asset result = assetSentimentDao.getAsset("assetId", AssetType.MOVIE);
+        assertEquals("assetTitle", result.title);
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/Asset.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/Asset.java
@@ -3,13 +3,11 @@ package com.google.moviestvsentiments.model;
 import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
-import androidx.room.TypeConverters;
 
 /**
  * A record in the assets database table.
  */
 @Entity(tableName = "assets_table", primaryKeys = {"asset_id", "asset_type"})
-@TypeConverters({AssetType.class})
 public class Asset {
 
     @NonNull
@@ -53,4 +51,20 @@ public class Asset {
 
     @ColumnInfo(name = "rt_rating")
     public String rottenTomatoesRating;
+    
+    public Asset(String id, AssetType type, String title, String poster, String banner, String plot,
+                 String runtime, String year, long timestamp, String imdbRating,
+                 String rottenTomatoesRating) {
+        this.id = id;
+        this.type = type;
+        this.title = title;
+        this.poster = poster;
+        this.banner = banner;
+        this.plot = plot;
+        this.runtime = runtime;
+        this.year = year;
+        this.timestamp = timestamp;
+        this.imdbRating = imdbRating;
+        this.rottenTomatoesRating = rottenTomatoesRating;
+    }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/UserSentiment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/UserSentiment.java
@@ -3,16 +3,12 @@ package com.google.moviestvsentiments.model;
 import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
-import androidx.room.ForeignKey;
-import androidx.room.TypeConverters;
 
 /**
  * A record in the user sentiments database table
  */
-@Entity(tableName = "user_sentiments_table", primaryKeys = {"asset_id", "account_name",
-    "asset_type"}, foreignKeys = @ForeignKey(entity = Asset.class, parentColumns = "asset_id",
-    childColumns = "asset_id", onDelete = ForeignKey.CASCADE))
-@TypeConverters({AssetType.class, SentimentType.class})
+@Entity(tableName = "user_sentiments_table",
+        primaryKeys = {"asset_id", "account_name", "asset_type"})
 public class UserSentiment {
 
     @NonNull

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDao.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDao.java
@@ -1,0 +1,30 @@
+package com.google.moviestvsentiments.service.assetSentiment;
+
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import com.google.moviestvsentiments.model.Asset;
+import com.google.moviestvsentiments.model.AssetType;
+import com.google.moviestvsentiments.model.SentimentType;
+import java.util.List;
+
+@Dao
+public abstract class AssetSentimentDao {
+
+    /**
+     * Adds the given asset into the assets table. If the asset already exists, it is ignored.
+     * @param asset The asset to insert.
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    public abstract void addAsset(Asset asset);
+
+    /**
+     * Returns the asset with the given id and type or null if it does not exist.
+     * @param assetId The id of the asset.
+     * @param assetType The type of the asset.
+     * @return The asset matching the id and type.
+     */
+    @Query("SELECT * FROM assets_table WHERE asset_id = :assetId AND asset_type = :assetType")
+    public abstract Asset getAsset(String assetId, AssetType assetType);
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/database/SentimentsDatabase.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/database/SentimentsDatabase.java
@@ -2,17 +2,30 @@ package com.google.moviestvsentiments.service.database;
 
 import androidx.room.Database;
 import androidx.room.RoomDatabase;
+import androidx.room.TypeConverters;
 import com.google.moviestvsentiments.model.Account;
+import com.google.moviestvsentiments.model.Asset;
+import com.google.moviestvsentiments.model.AssetType;
+import com.google.moviestvsentiments.model.SentimentType;
+import com.google.moviestvsentiments.model.UserSentiment;
 import com.google.moviestvsentiments.service.account.AccountDao;
+import com.google.moviestvsentiments.service.assetSentiment.AssetSentimentDao;
 
 /**
  * A high-level interface for performing database queries.
  */
-@Database(entities = {Account.class}, version = 1, exportSchema = false)
+@Database(entities = {Account.class, Asset.class, UserSentiment.class}, version = 1,
+        exportSchema = false)
+@TypeConverters({AssetType.class, SentimentType.class})
 public abstract class SentimentsDatabase extends RoomDatabase {
 
     /**
      * Returns an object that performs queries on the accounts table.
      */
     public abstract AccountDao accountDao();
+
+    /**
+     * Returns an object that performs queries on the assets and user sentiments tables.
+     */
+    public abstract AssetSentimentDao assetSentimentDao();
 }


### PR DESCRIPTION
Adds the AssetSentimentDao and corresponding unit tests. Only the addAsset and getAsset methods of the AssetSentimentDao are added. The remaining methods will be added in the next pull request.

The foreign key annotation on the UserSentiment entity was removed because Room was complaining that it would cause a full table scan every time the assets table was updated.