### PR TITLE
Use truth assertions in unit tests

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -50,4 +50,6 @@ dependencies {
 
     // Testing
     androidTestImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"
+    androidTestImplementation 'androidx.test.ext:truth:1.0.0'
+    androidTestImplementation "com.google.truth:truth:$rootProject.truthVersion"
 }

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/account/AccountDaoTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/account/AccountDaoTest.java
@@ -1,9 +1,6 @@
 package com.google.moviestvsentiments.service.account;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
@@ -45,22 +42,24 @@ public class AccountDaoTest {
     public void addAndGetAccount_returnsName() {
         accountDao.addAccount("John Doe");
         List<Account> accounts = accountDao.getAlphabetizedAccounts();
-        assertEquals("John Doe", accounts.get(0).name);
-        assertTrue(accounts.get(0).timestamp > 0);
+
+        assertThat(accounts.get(0).name).isEqualTo("John Doe");
     }
 
     @Test
     public void addAndGetAccount_returnsIsCurrent() {
         accountDao.addAccount("John Doe");
         List<Account> accounts = accountDao.getAlphabetizedAccounts();
-        assertFalse(accounts.get(0).isCurrent);
+
+        assertThat(accounts.get(0).isCurrent).isFalse();
     }
 
     @Test
     public void addAndGetAccount_returnsTimestamp() {
         accountDao.addAccount("John Doe");
         List<Account> accounts = accountDao.getAlphabetizedAccounts();
-        assertTrue(accounts.get(0).timestamp > 0);
+
+        assertThat(accounts.get(0).timestamp).isGreaterThan(0);
     }
 
     @Test
@@ -68,9 +67,10 @@ public class AccountDaoTest {
         accountDao.addAccount("John Doe");
         accountDao.addAccount("Jane Doe");
         List<Account> accounts = accountDao.getAlphabetizedAccounts();
-        assertEquals(2, accounts.size());
-        assertEquals("Jane Doe", accounts.get(0).name);
-        assertEquals("John Doe", accounts.get(1).name);
+
+        assertThat(accounts).hasSize(2);
+        assertThat(accounts.get(0).name).isEqualTo("Jane Doe");
+        assertThat(accounts.get(1).name).isEqualTo("John Doe");
     }
 
     @Test
@@ -78,34 +78,41 @@ public class AccountDaoTest {
         accountDao.addAccount("John Doe");
         accountDao.addAccount("John Doe");
         List<Account> accounts = accountDao.getAlphabetizedAccounts();
-        assertEquals(1, accounts.size());
+
+        assertThat(accounts).hasSize(1);
     }
 
     @Test
     public void setIsCurrent_nonexistentAccount_returnsFalse() {
         boolean updated = accountDao.setIsCurrent("Nonexistent Account", false);
-        assertFalse(updated);
+
+        assertThat(updated).isFalse();
     }
 
     @Test
     public void setIsCurrent_existingAccount_returnsTrue() {
         accountDao.addAccount("Existing Account");
+
         boolean updated = accountDao.setIsCurrent("Existing Account", false);
-        assertTrue(updated);
+
+        assertThat(updated).isTrue();
     }
 
     @Test
     public void getCurrentAccount_withNoCurrentSet_returnsNull() {
         Account account = accountDao.getCurrentAccount();
-        assertNull(account);
+
+        assertThat(account).isNull();
     }
 
     @Test
     public void getCurrentAccount_withCurrentSet_returnsAccount() {
         accountDao.addAccount("John Doe");
         accountDao.setIsCurrent("John Doe", true);
+
         Account account = accountDao.getCurrentAccount();
-        assertEquals("John Doe", account.name);
-        assertTrue(account.isCurrent);
+
+        assertThat(account.name).isEqualTo("John Doe");
+        assertThat(account.isCurrent).isTrue();
     }
 }

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDaoTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDaoTest.java
@@ -1,12 +1,8 @@
 package com.google.moviestvsentiments.service.assetSentiment;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
 
 import android.content.Context;
-import android.provider.Telephony;
-
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.room.Room;
 import androidx.test.core.app.ApplicationProvider;
@@ -59,7 +55,7 @@ public class AssetSentimentDaoTest {
         assetSentimentDao.addAsset(MOVIE_ASSET);
         AssetSentiment result = assetSentimentDao.getAsset("accountName", "incorrectId", AssetType.MOVIE);
 
-        assertNull(result);
+        assertThat(result).isNull();
     }
 
     @Test
@@ -67,7 +63,7 @@ public class AssetSentimentDaoTest {
         assetSentimentDao.addAsset(MOVIE_ASSET);
         AssetSentiment result = assetSentimentDao.getAsset("accountName", "assetId", AssetType.SHOW);
 
-        assertNull(result);
+        assertThat(result).isNull();
     }
 
     @Test
@@ -75,7 +71,7 @@ public class AssetSentimentDaoTest {
         assetSentimentDao.addAsset(MOVIE_ASSET);
         AssetSentiment result = assetSentimentDao.getAsset("accountName", "assetId", AssetType.MOVIE);
 
-        assertEquals("assetTitle", result.asset.title());
+        assertThat(result.asset()).isEqualTo(MOVIE_ASSET);
     }
 
     @Test
@@ -83,18 +79,18 @@ public class AssetSentimentDaoTest {
         assetSentimentDao.addAsset(MOVIE_ASSET);
         AssetSentiment result = assetSentimentDao.getAsset("accountName", "assetId", AssetType.MOVIE);
 
-        assertEquals(SentimentType.UNSPECIFIED, result.sentimentType);
+        assertThat(result.sentimentType()).isEqualTo(SentimentType.UNSPECIFIED);
     }
 
     @Test
-    public void addAndGetAsset_withSentiment_returnsSentiment() {
+    public void addAndGetAsset_withSentiment_returnsAssetSentiment() {
         assetSentimentDao.addAsset(MOVIE_ASSET);
         assetSentimentDao.updateSentiment("accountName", "assetId",
                 AssetType.MOVIE, SentimentType.THUMBS_UP);
 
         AssetSentiment result = assetSentimentDao.getAsset("accountName", "assetId", AssetType.MOVIE);
 
-        assertEquals(SentimentType.THUMBS_UP, result.sentimentType);
+        assertThat(result).isEqualTo(AssetSentiment.create(MOVIE_ASSET, SentimentType.THUMBS_UP));
     }
 
     @Test
@@ -106,7 +102,7 @@ public class AssetSentimentDaoTest {
         List<AssetSentiment> results = assetSentimentDao.getAssets(AssetType.SHOW, "accountName",
                 SentimentType.UNSPECIFIED);
 
-        assertEquals(0, results.size());
+        assertThat(results).isEmpty();
     }
 
     @Test
@@ -118,7 +114,7 @@ public class AssetSentimentDaoTest {
         List<AssetSentiment> results = assetSentimentDao.getAssets(AssetType.MOVIE, "incorrectName",
                 SentimentType.THUMBS_UP);
 
-        assertEquals(0, results.size());
+        assertThat(results).isEmpty();
     }
 
     @Test
@@ -130,11 +126,11 @@ public class AssetSentimentDaoTest {
         List<AssetSentiment> results = assetSentimentDao.getAssets(AssetType.MOVIE, "accountName",
                 SentimentType.THUMBS_DOWN);
 
-        assertEquals(0, results.size());
+        assertThat(results).isEmpty();
     }
 
     @Test
-    public void updateSentimentAndGetAssets_multipleAssets_returnsAllAssets() {
+    public void updateSentimentAndGetAssets_multipleAssets_returnsAllAssetSentiments() {
         assetSentimentDao.addAsset(MOVIE_ASSET);
         assetSentimentDao.addAsset(MOVIE_ASSET_2);
 
@@ -145,26 +141,13 @@ public class AssetSentimentDaoTest {
         List<AssetSentiment> results = assetSentimentDao.getAssets(AssetType.MOVIE, "accountName",
                 SentimentType.THUMBS_UP);
 
-        assertEquals(2, results.size());
-        assertEquals("assetId", results.get(0).asset.id());
-        assertEquals("assetId2", results.get(1).asset.id());
+        assertThat(results).containsExactly(
+                AssetSentiment.create(MOVIE_ASSET, SentimentType.THUMBS_UP),
+                AssetSentiment.create(MOVIE_ASSET_2, SentimentType.THUMBS_UP));
     }
 
     @Test
-    public void updateSentimentAndGetAssets_returnsSentimentValue() {
-        assetSentimentDao.addAsset(MOVIE_ASSET);
-
-        assetSentimentDao.updateSentiment("accountName", "assetId",
-                AssetType.MOVIE, SentimentType.THUMBS_DOWN);
-        List<AssetSentiment> results = assetSentimentDao.getAssets(AssetType.MOVIE, "accountName",
-                SentimentType.THUMBS_DOWN);
-
-        assertEquals(1, results.size());
-        assertEquals(SentimentType.THUMBS_DOWN, results.get(0).sentimentType);
-    }
-
-    @Test
-    public void updateSentimentAndGetAssets_unspecifiedSentiment_returnsAllAssets() {
+    public void updateSentimentAndGetAssets_unspecifiedSentiment_returnsAllAssetSentiments() {
         assetSentimentDao.addAsset(MOVIE_ASSET);
         assetSentimentDao.addAsset(MOVIE_ASSET_2);
 
@@ -173,24 +156,9 @@ public class AssetSentimentDaoTest {
         List<AssetSentiment> results = assetSentimentDao.getAssets(AssetType.MOVIE, "accountName",
                 SentimentType.UNSPECIFIED);
 
-        assertEquals(2, results.size());
-        assertEquals("assetId", results.get(0).asset.id());
-        assertEquals("assetId2", results.get(1).asset.id());
-    }
-
-    @Test
-    public void updateSentimentAndGetAssets_unspecifiedSentiment_returnsSentimentValue() {
-        assetSentimentDao.addAsset(MOVIE_ASSET);
-        assetSentimentDao.addAsset(MOVIE_ASSET_2);
-
-        assetSentimentDao.updateSentiment("accountName", "assetId",
-                AssetType.MOVIE, SentimentType.UNSPECIFIED);
-        List<AssetSentiment> results = assetSentimentDao.getAssets(AssetType.MOVIE, "accountName",
-                SentimentType.UNSPECIFIED);
-
-        assertEquals(2, results.size());
-        assertEquals(SentimentType.UNSPECIFIED, results.get(0).sentimentType);
-        assertEquals(SentimentType.UNSPECIFIED, results.get(1).sentimentType);
+        assertThat(results).containsExactly(
+                AssetSentiment.create(MOVIE_ASSET, SentimentType.UNSPECIFIED),
+                AssetSentiment.create(MOVIE_ASSET_2, SentimentType.UNSPECIFIED));
     }
 
     @Test
@@ -203,7 +171,7 @@ public class AssetSentimentDaoTest {
         List<AssetSentiment> results = assetSentimentDao.getAssets(AssetType.MOVIE, "accountName",
                 SentimentType.THUMBS_UP);
 
-        assertEquals(0, results.size());
+        assertThat(results).isEmpty();
     }
 
     @Test
@@ -216,7 +184,6 @@ public class AssetSentimentDaoTest {
         List<AssetSentiment> results = assetSentimentDao.getAssets(AssetType.MOVIE, "accountName",
                 SentimentType.THUMBS_UP);
 
-        assertEquals(1, results.size());
-        assertEquals("assetTitle", results.get(0).asset.title());
+        assertThat(results).containsExactly(AssetSentiment.create(MOVIE_ASSET, SentimentType.THUMBS_UP));
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/AssetSentiment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/AssetSentiment.java
@@ -2,10 +2,25 @@ package com.google.moviestvsentiments.model;
 
 import androidx.room.Embedded;
 
+import com.google.auto.value.AutoValue;
+
 /**
  * A container that combines an asset with a sentiment type.
  */
-public class AssetSentiment {
-    @Embedded public Asset asset;
-    public SentimentType sentimentType;
+@AutoValue
+public abstract class AssetSentiment {
+    @AutoValue.CopyAnnotations
+    @Embedded
+    public abstract Asset asset();
+
+    public abstract SentimentType sentimentType();
+
+    /**
+     * Creates a new AssetSentiment object with the given fields. Room needs this factory method to
+     * create AssetSentiment objects.
+     * @return A new AssetSentiment object with the specified fields.
+     */
+    public static AssetSentiment create(Asset asset, SentimentType sentimentType) {
+        return new AutoValue_AssetSentiment(asset, sentimentType);
+    }
 }

--- a/MoviesTVSentiments/build.gradle
+++ b/MoviesTVSentiments/build.gradle
@@ -28,4 +28,5 @@ ext {
     roomVersion = '2.2.1'
     archLifecycleVersion = '2.2.0'
     coreTestingVersion = '2.1.0'
+    truthVersion = '1.0.1'
 }


### PR DESCRIPTION
Removes JUnit assertions and replaces them with truth assertions. Also makes the AssetSentiment class an AutoValue class in order to simplify the assertions. Two newly-redundant tests are then removed from AssetSentimentDaoTest.