### PR TITLE
Add AccountRepository and unit tests, move LiveDataTestUtil

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -25,6 +25,11 @@ android {
         sourceCompatibility = 1.8
         targetCompatibility = 1.8
     }
+
+    sourceSets {
+        androidTest.java.srcDirs += "src/test-common/java"
+        test.java.srcDirs += "src/test-common/java"
+    }
 }
 
 dependencies {
@@ -52,4 +57,7 @@ dependencies {
     androidTestImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"
     androidTestImplementation 'androidx.test.ext:truth:1.0.0'
     androidTestImplementation "com.google.truth:truth:$rootProject.truthVersion"
+    testImplementation "org.mockito:mockito-core:1.10.19"
+    testImplementation "com.google.truth:truth:$rootProject.truthVersion"
+    testImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"
 }

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/account/AccountDaoTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/account/AccountDaoTest.java
@@ -9,7 +9,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.moviestvsentiments.model.Account;
 import com.google.moviestvsentiments.service.database.SentimentsDatabase;
-import com.google.moviestvsentiments.service.liveData.LiveDataTestUtil;
+import com.google.moviestvsentiments.util.LiveDataTestUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDaoTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDaoTest.java
@@ -12,8 +12,7 @@ import com.google.moviestvsentiments.model.AssetSentiment;
 import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
 import com.google.moviestvsentiments.service.database.SentimentsDatabase;
-import com.google.moviestvsentiments.service.liveData.LiveDataTestUtil;
-
+import com.google.moviestvsentiments.util.LiveDataTestUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountRepository.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountRepository.java
@@ -1,0 +1,60 @@
+package com.google.moviestvsentiments.service.account;
+
+import androidx.lifecycle.LiveData;
+import com.google.moviestvsentiments.model.Account;
+import java.util.List;
+
+/**
+ * A repository that handles fetching and updating accounts.
+ */
+public class AccountRepository {
+
+    private final AccountDao accountDao;
+
+    private AccountRepository(AccountDao accountDao) {
+        this.accountDao = accountDao;
+    }
+
+    /**
+     * Returns a new AccountRepository object.
+     * @param accountDao The Dao object to use when accessing the local database.
+     * @return A new AccountRepository object.
+     */
+    public static AccountRepository create(AccountDao accountDao) {
+        return new AccountRepository(accountDao);
+    }
+
+    /**
+     * Adds the given account name into the accounts table. If the name already exists,
+     * it is ignored. The account record is created with is_current set to false.
+     * @param name The name of the account to add.
+     */
+    void addAccount(String name) {
+        accountDao.addAccount(name);
+    }
+
+    /**
+     * Returns a LiveData list of all accounts sorted by name in alphabetical order.
+     */
+    LiveData<List<Account>> getAllAccounts() {
+        return accountDao.getAlphabetizedAccounts();
+    }
+
+    /**
+     * Returns a LiveData object containing the currently signed-in account or null if all accounts
+     * are signed out.
+     */
+    LiveData<Account> getCurrentAccount() {
+        return accountDao.getCurrentAccount();
+    }
+
+    /**
+     * Updates the given account record's is_current value.
+     * @param name The name of the account to update.
+     * @param isCurrent The value to set is_current to.
+     * @return True if the record exists and was updated successfully.
+     */
+    boolean setIsCurrent(String name, boolean isCurrent) {
+        return accountDao.setIsCurrent(name, isCurrent);
+    }
+}

--- a/MoviesTVSentiments/app/src/test-common/java/com/google/moviestvsentiments/util/LiveDataTestUtil.java
+++ b/MoviesTVSentiments/app/src/test-common/java/com/google/moviestvsentiments/util/LiveDataTestUtil.java
@@ -1,4 +1,4 @@
-package com.google.moviestvsentiments.service.liveData;
+package com.google.moviestvsentiments.util;
 
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.Observer;

--- a/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/account/AccountRepositoryTest.java
+++ b/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/account/AccountRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.google.moviestvsentiments.service.account;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.MutableLiveData;
+import com.google.moviestvsentiments.model.Account;
+import com.google.moviestvsentiments.util.LiveDataTestUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(JUnit4.class)
+public class AccountRepositoryTest {
+
+    private static final Account ACCOUNT = createAccount("Account Name", 1337, true);
+
+    private static Account createAccount(String accountName, long timestamp, boolean isCurrent) {
+        Account account = new Account();
+        account.name = accountName;
+        account.timestamp = timestamp;
+        account.isCurrent = isCurrent;
+        return account;
+    }
+
+    @Rule
+    public InstantTaskExecutorRule instantExecutorRule = new InstantTaskExecutorRule();
+
+    private AccountDao dao;
+    private AccountRepository repository;
+
+    @Before
+    public void setUp() {
+        dao = mock(AccountDao.class);
+        repository = AccountRepository.create(dao);
+    }
+
+    @Test
+    public void addAccount_invokesDao() {
+        repository.addAccount("Account Name");
+
+        verify(dao).addAccount("Account Name");
+    }
+
+    @Test
+    public void getAllAccounts_returnsAccounts() {
+        MutableLiveData<List<Account>> accountsData = new MutableLiveData<>();
+        accountsData.setValue(Arrays.asList(ACCOUNT));
+        when(dao.getAlphabetizedAccounts()).thenReturn(accountsData);
+
+        List<Account> results = LiveDataTestUtil.getValue(repository.getAllAccounts());
+
+        assertThat(results).containsExactly(ACCOUNT);
+    }
+
+    @Test
+    public void getCurrentAccount_returnsAccount() {
+        MutableLiveData<Account> accountData = new MutableLiveData<>();
+        accountData.setValue(ACCOUNT);
+        when(dao.getCurrentAccount()).thenReturn(accountData);
+
+        Account result = LiveDataTestUtil.getValue(repository.getCurrentAccount());
+
+        assertThat(result).isEqualTo(ACCOUNT);
+    }
+
+    @Test
+    public void setIsCurrent_invokesDao() {
+        repository.setIsCurrent("Account Name", false);
+
+        verify(dao).setIsCurrent("Account Name", false);
+    }
+}


### PR DESCRIPTION
Adds a very basic AccountRepository that simply acts as a wrapper around the AccountDao. More functionality will be added when the WebService is integrated.

The LiveDataTestUtil class is moved to a test-common directory so that Android instrumentation tests and regular unit tests can both access it.