### PR TITLE
Add AccountViewModel and unit tests

### DIFF
--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountViewModel.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountViewModel.java
@@ -1,0 +1,61 @@
+package com.google.moviestvsentiments.service.account;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.ViewModel;
+import com.google.moviestvsentiments.model.Account;
+import java.util.List;
+
+/**
+ * A ViewModel that handles fetching and updating accounts.
+ */
+public class AccountViewModel extends ViewModel {
+
+    private AccountRepository repository;
+
+    private AccountViewModel(AccountRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Returns a new AccountViewModel object.
+     * @param repository The repository to use when accessing accounts.
+     * @return A new AccountViewModel object.
+     */
+    public static AccountViewModel create(AccountRepository repository) {
+        return new AccountViewModel(repository);
+    }
+
+    /**
+     * Adds the given account name into the accounts table. If the name already exists,
+     * it is ignored. The account record is created with is_current set to false.
+     * @param name The name of the account to add.
+     */
+    public void addAccount(String name) {
+        repository.addAccount(name);
+    }
+
+    /**
+     * Returns a LiveData list of all accounts sorted by name in alphabetical order.
+     */
+    public LiveData<List<Account>> getAlphabetizedAccounts() {
+        return repository.getAlphabetizedAccounts();
+    }
+
+    /**
+     * Returns a LiveData object containing the currently signed-in account or null if all accounts
+     * are signed out.
+     */
+    public LiveData<Account> getCurrentAccount() {
+        return repository.getCurrentAccount();
+    }
+
+    /**
+     * Updates the given account record's is_current value.
+     * @param name The name of the account to update.
+     * @param isCurrent The value to set is_current to.
+     * @return True if the record exists and was updated successfully.
+     */
+    public boolean setIsCurrent(String name, boolean isCurrent) {
+        return repository.setIsCurrent(name, isCurrent);
+    }
+}

--- a/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/account/AccountViewModelTest.java
+++ b/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/account/AccountViewModelTest.java
@@ -1,0 +1,80 @@
+package com.google.moviestvsentiments.service.account;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.MutableLiveData;
+import com.google.moviestvsentiments.model.Account;
+import com.google.moviestvsentiments.util.LiveDataTestUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(JUnit4.class)
+public class AccountViewModelTest {
+
+    private static final Account ACCOUNT = createAccount("Account Name", 13, true);
+
+    private static Account createAccount(String accountName, long timestamp, boolean isCurrent) {
+        Account account = new Account();
+        account.name = accountName;
+        account.timestamp = timestamp;
+        account.isCurrent = isCurrent;
+        return account;
+    }
+
+    @Rule
+    public InstantTaskExecutorRule instantExecutorRule = new InstantTaskExecutorRule();
+
+    private AccountRepository repository;
+    private AccountViewModel viewModel;
+
+    @Before
+    public void setUp() {
+        repository = mock(AccountRepository.class);
+        viewModel = AccountViewModel.create(repository);
+    }
+
+    @Test
+    public void addAccount_invokesRepository() {
+        viewModel.addAccount("Account Name");
+
+        verify(repository).addAccount("Account Name");
+    }
+
+    @Test
+    public void getAlphabetizedAccounts_returnsAccounts() {
+        MutableLiveData<List<Account>> accountsData = new MutableLiveData<>();
+        accountsData.setValue(Arrays.asList(ACCOUNT));
+        when(repository.getAlphabetizedAccounts()).thenReturn(accountsData);
+
+        List<Account> results = LiveDataTestUtil.getValue(viewModel.getAlphabetizedAccounts());
+
+        assertThat(results).containsExactly(ACCOUNT);
+    }
+
+    @Test
+    public void getCurrentAccount_returnsAccount() {
+        MutableLiveData<Account> accountData = new MutableLiveData<>();
+        accountData.setValue(ACCOUNT);
+        when(repository.getCurrentAccount()).thenReturn(accountData);
+
+        Account result = LiveDataTestUtil.getValue(viewModel.getCurrentAccount());
+
+        assertThat(result).isEqualTo(ACCOUNT);
+    }
+
+    @Test
+    public void setIsCurrent_invokesRepository() {
+        viewModel.setIsCurrent("Account Name", true);
+
+        verify(repository).setIsCurrent("Account Name", true);
+    }
+}


### PR DESCRIPTION
Adds AccountViewModel that acts as a wrapper around the AccountRepository and the unit tests for it. These files shouldn't need to change when the WebService is integrated, but may change slightly when Hilt/Dagger is used.