### PR TITLE
Add CI workflow to run JUnit and Espresso tests

### DIFF
--- a/.github/workflows/test-workflow.yaml
+++ b/.github/workflows/test-workflow.yaml
@@ -1,0 +1,27 @@
+name: Test
+on: push
+
+jobs:
+  test:
+    name: Run Unit Tests
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8      
+
+      - name: Run JUnit tests
+        run: bash ./gradlew test
+        working-directory: ./MoviesTVSentiments
+
+      - name: Run Espresso tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          working-directory: ./MoviesTVSentiments
+          api-level: 29
+          script: ./gradlew connectedAndroidTest --info
+

--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -32,6 +32,14 @@ android {
     }
 }
 
+tasks.withType(Test) {
+    testLogging {
+        exceptionFormat "full"
+        events "skipped", "passed", "failed"
+        showStandardStreams true
+    }
+}
+
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.1.0'


### PR DESCRIPTION
The results of the workflow can be seen on the "Actions" tab of the Github repo. It takes about 3-4 minutes to run. The workflow is currently set to run anytime a push is made to any branch.