### PR TITLE
Add AssetSentimentViewModel and unit tests

### DIFF
--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentViewModel.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentViewModel.java
@@ -1,0 +1,89 @@
+package com.google.moviestvsentiments.service.assetSentiment;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.ViewModel;
+import com.google.moviestvsentiments.model.Asset;
+import com.google.moviestvsentiments.model.AssetSentiment;
+import com.google.moviestvsentiments.model.AssetType;
+import com.google.moviestvsentiments.model.SentimentType;
+import java.util.List;
+
+/**
+ * A ViewModel that handles fetching and updating assets and user sentiments.
+ */
+public class AssetSentimentViewModel extends ViewModel {
+
+    private final AssetSentimentRepository repository;
+
+    private AssetSentimentViewModel(AssetSentimentRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Returns a new AssetSentimentViewModel.
+     * @param repository The repository object to use when accessing assets and user sentiments.
+     * @return A new AssetSentimentViewModel object.
+     */
+    public static AssetSentimentViewModel create(AssetSentimentRepository repository) {
+        return new AssetSentimentViewModel(repository);
+    }
+
+    /**
+     * Adds the given asset into the assets table. If the asset already exists, it is ignored.
+     * @param asset The asset to insert.
+     */
+    public void addAsset(Asset asset) {
+        repository.addAsset(asset);
+    }
+
+    /**
+     * Returns a LiveData object containing the asset with the given id and type or null if the
+     * asset does not exist. The asset is combined with the matching user sentiment and returned as
+     * an AssetSentiment object.
+     * @param accountName The name of the account to match with the sentiment.
+     * @param assetId The id of the asset.
+     * @param assetType The type of the asset.
+     * @return A LiveData object containing the AssetSentiment matching the account name, asset id
+     * and asset type.
+     */
+    public LiveData<AssetSentiment> getAsset(String accountName, String assetId,
+                                             AssetType assetType) {
+        return repository.getAsset(accountName, assetId, assetType);
+    }
+
+    /**
+     * Returns a LiveData list of AssetSentiments matching the given type that have been reacted to
+     * with the given sentiment by the given account. If the sentiment type is UNSPECIFIED, assets
+     * with no corresponding user sentiment record will also be returned.
+     * @param assetType The type of asset to include in the results.
+     * @param accountName The account name to use when checking assets for sentiments.
+     * @param sentimentType The sentiment type to check for.
+     * @return A LiveData list of AssetSentiments with reactions matching the given account
+     * name and sentiment type.
+     */
+    public LiveData<List<AssetSentiment>> getAssets(AssetType assetType, String accountName,
+                                                    SentimentType sentimentType) {
+        return repository.getAssets(assetType, accountName, sentimentType);
+    }
+
+    /**
+     * Inserts or replaces the user sentiment specified by the asset and account with the given
+     * sentiment type.
+     * @param accountName The account that the user sentiment is associated with.
+     * @param assetId The id of the asset that the user sentiment is associated with.
+     * @param assetType The type of the asset that the user sentiment is associated with.
+     * @param sentimentType The type of the new user sentiment.
+     */
+    public void updateSentiment(String accountName, String assetId, AssetType assetType,
+                                SentimentType sentimentType) {
+        repository.updateSentiment(accountName, assetId, assetType, sentimentType);
+    }
+
+    /**
+     * Deletes all user sentiments corresponding to the given account name.
+     * @param accountName The account to delete all sentiments for.
+     */
+    public void deleteAllSentiments(String accountName) {
+        repository.deleteAllSentiments(accountName);
+    }
+}

--- a/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentViewModelTest.java
+++ b/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentViewModelTest.java
@@ -1,0 +1,90 @@
+package com.google.moviestvsentiments.service.assetSentiment;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.MutableLiveData;
+import com.google.moviestvsentiments.model.Asset;
+import com.google.moviestvsentiments.model.AssetSentiment;
+import com.google.moviestvsentiments.model.AssetType;
+import com.google.moviestvsentiments.model.SentimentType;
+import com.google.moviestvsentiments.util.LiveDataTestUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(JUnit4.class)
+public class AssetSentimentViewModelTest {
+
+    private static final Asset ASSET = Asset.builder().setId("assetId").setType(AssetType.SHOW)
+            .setTitle("assetTitle").setPoster("posterURL").setBanner("bannerURL").setYear("year")
+            .setPlot("plotDescription").setRuntime("runtime").setTimestamp(1).build();
+
+    @Rule
+    public InstantTaskExecutorRule instantExecutorRule = new InstantTaskExecutorRule();
+
+    private AssetSentimentRepository repository;
+    private AssetSentimentViewModel viewModel;
+
+    @Before
+    public void setUp() {
+        repository = mock(AssetSentimentRepository.class);
+        viewModel = AssetSentimentViewModel.create(repository);
+    }
+
+    @Test
+    public void addAsset_invokesRepository() {
+        viewModel.addAsset(ASSET);
+
+        verify(repository).addAsset(ASSET);
+    }
+
+    @Test
+    public void getAsset_returnsAsset() {
+        MutableLiveData<AssetSentiment> assetData = new MutableLiveData<>();
+        assetData.setValue(AssetSentiment.create(ASSET, SentimentType.THUMBS_DOWN));
+        when(repository.getAsset("Account Name", "assetId", AssetType.SHOW))
+                .thenReturn(assetData);
+
+        AssetSentiment result = LiveDataTestUtil.getValue(viewModel.getAsset("Account Name",
+                "assetId", AssetType.SHOW));
+
+        assertThat(result).isEqualTo(AssetSentiment.create(ASSET, SentimentType.THUMBS_DOWN));
+    }
+
+    @Test
+    public void getAssets_returnsAssets() {
+        MutableLiveData<List<AssetSentiment>> assetData = new MutableLiveData<>();
+        assetData.setValue(Arrays.asList(AssetSentiment.create(ASSET, SentimentType.UNSPECIFIED)));
+        when(repository.getAssets(AssetType.SHOW, "Account Name", SentimentType.UNSPECIFIED))
+                .thenReturn(assetData);
+
+        List<AssetSentiment> result = LiveDataTestUtil.getValue(viewModel.getAssets(AssetType.SHOW,
+                "Account Name", SentimentType.UNSPECIFIED));
+
+        assertThat(result).containsExactly(AssetSentiment.create(ASSET, SentimentType.UNSPECIFIED));
+    }
+
+    @Test
+    public void updateSentiment_invokesRepository() {
+        viewModel.updateSentiment("Account Name", "assetId", AssetType.SHOW,
+                SentimentType.THUMBS_UP);
+
+        verify(repository).updateSentiment("Account Name", "assetId", AssetType.SHOW,
+                SentimentType.THUMBS_UP);
+    }
+
+    @Test
+    public void deleteAllSentiments_invokesRepository() {
+        viewModel.deleteAllSentiments("Account Name");
+
+        verify(repository).deleteAllSentiments("Account Name");
+    }
+}


### PR DESCRIPTION
Adds AssetSentimentViewModel that acts as a wrapper around the AssetSentimentRepository. Also adds the unit tests for it. 