### PR TITLE
Add SigninActivity and integration tests

### DIFF
--- a/MoviesTVSentiments/.idea/misc.xml
+++ b/MoviesTVSentiments/.idea/misc.xml
@@ -1,5 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="NullableNotNullManager">
+    <option name="myDefaultNullable" value="org.jetbrains.annotations.Nullable" />
+    <option name="myDefaultNotNull" value="androidx.annotation.NonNull" />
+    <option name="myNullables">
+      <value>
+        <list size="12">
+          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
+          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
+          <item index="3" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+          <item index="4" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+          <item index="5" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
+          <item index="6" class="java.lang.String" itemvalue="android.annotation.Nullable" />
+          <item index="7" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="10" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
+          <item index="11" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
+        </list>
+      </value>
+    </option>
+    <option name="myNotNulls">
+      <value>
+        <list size="11">
+          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
+          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
+          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
+          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+          <item index="4" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
+          <item index="5" class="java.lang.String" itemvalue="android.annotation.NonNull" />
+          <item index="6" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
+          <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
+          <item index="10" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
+        </list>
+      </value>
+    </option>
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -12,7 +12,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "com.google.moviestvsentiments.HiltTestRunner"
     }
 
     buildTypes {
@@ -62,6 +62,8 @@ dependencies {
     // Hilt
     implementation "com.google.dagger:hilt-android:$rootProject.hiltVersion"
     annotationProcessor "com.google.dagger:hilt-android-compiler:$rootProject.hiltVersion"
+    androidTestImplementation "com.google.dagger:hilt-android-testing:$rootProject.hiltVersion"
+    androidTestAnnotationProcessor "com.google.dagger:hilt-android-compiler:$rootProject.hiltVersion"
 
     // Room components
     implementation "androidx.room:room-runtime:$rootProject.roomVersion"
@@ -73,6 +75,7 @@ dependencies {
     annotationProcessor "androidx.lifecycle:lifecycle-compiler:$rootProject.archLifecycleVersion"
 
     // Testing
+    androidTestImplementation "androidx.test:rules:1.1.0"
     androidTestImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"
     androidTestImplementation 'androidx.test.ext:truth:1.0.0'
     androidTestImplementation "com.google.truth:truth:$rootProject.truthVersion"

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/HiltTestRunner.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/HiltTestRunner.java
@@ -1,0 +1,18 @@
+package com.google.moviestvsentiments;
+
+import android.app.Application;
+import android.content.Context;
+import androidx.test.runner.AndroidJUnitRunner;
+import dagger.hilt.android.testing.HiltTestApplication;
+
+/**
+ * A test runner that uses Hilt for dependency injection.
+ */
+public class HiltTestRunner extends AndroidJUnitRunner {
+
+    @Override
+    public Application newApplication(ClassLoader cl, String className, Context context)
+        throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+        return super.newApplication(cl, HiltTestApplication.class.getName(), context);
+    }
+}

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/InMemoryDatabaseModule.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/InMemoryDatabaseModule.java
@@ -1,0 +1,38 @@
+package com.google.moviestvsentiments;
+
+import android.content.Context;
+import androidx.room.Room;
+import com.google.moviestvsentiments.service.account.AccountDao;
+import com.google.moviestvsentiments.service.assetSentiment.AssetSentimentDao;
+import com.google.moviestvsentiments.service.database.SentimentsDatabase;
+import javax.inject.Singleton;
+import dagger.Module;
+import dagger.Provides;
+import dagger.hilt.InstallIn;
+import dagger.hilt.android.components.ApplicationComponent;
+import dagger.hilt.android.qualifiers.ApplicationContext;
+
+/**
+ * A Hilt module that provides in-memory database and dao objects.
+ */
+@Module
+@InstallIn(ApplicationComponent.class)
+public class InMemoryDatabaseModule {
+
+    @Provides
+    @Singleton
+    public SentimentsDatabase provideSentimentsDatabase(@ApplicationContext Context context) {
+        return Room.inMemoryDatabaseBuilder(context, SentimentsDatabase.class)
+                .allowMainThreadQueries().build();
+    }
+
+    @Provides
+    public AccountDao provideAccountDao(SentimentsDatabase database) {
+        return database.accountDao();
+    }
+
+    @Provides
+    public AssetSentimentDao provideAssetSentimentDao(SentimentsDatabase database) {
+        return database.assetSentimentDao();
+    }
+}

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
@@ -1,0 +1,41 @@
+package com.google.moviestvsentiments.usecase.signin;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import dagger.hilt.android.testing.HiltAndroidRule;
+import dagger.hilt.android.testing.HiltAndroidTest;
+import dagger.hilt.android.testing.UninstallModules;
+import androidx.test.rule.ActivityTestRule;
+import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.di.DatabaseModule;
+
+@UninstallModules(DatabaseModule.class)
+@HiltAndroidTest
+public class SigninActivityTest {
+
+    @Rule
+    public RuleChain rule = RuleChain.outerRule(new HiltAndroidRule(this))
+            .around(new ActivityTestRule<>(SigninActivity.class));
+
+    @Test
+    public void signinActivity_displaysOnlyAddAccount() {
+        onView(withId(R.id.accountTextView)).check(matches(withText("Add Account")));
+    }
+
+    @Test
+    public void signinActivity_clickAddAccount_addsAccount() {
+        onView(withId(R.id.accountTextView)).perform(click());
+
+        onView(allOf(withId(R.id.accountTextView), not(withText("Add Account"))))
+                .check(matches(withText("Test Account")));
+    }
+}

--- a/MoviesTVSentiments/app/src/main/AndroidManifest.xml
+++ b/MoviesTVSentiments/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".usecase.signin.SigninActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/AccountListAdapter.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/AccountListAdapter.java
@@ -1,0 +1,116 @@
+package com.google.moviestvsentiments.usecase.signin;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.model.Account;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An adapter that binds a list of account objects to views for display in a RecyclerView. In
+ * addition to the given accounts, an "Add Account" view will be displayed.
+ */
+class AccountListAdapter extends RecyclerView.Adapter<AccountListAdapter.AccountViewHolder> {
+
+    /**
+     * Provides callbacks to be invoked when an account is clicked.
+     */
+    interface AccountClickListener {
+        /**
+         * Handles an account in the account list being clicked.
+         * @param addAccount True if the user has requested to add a new account. False if the user
+         *                   has selected an existing account.
+         * @param accountName The name of the selected account or "Add Account" if addAccount is
+         *                    true.
+         */
+        void onAccountClick(boolean addAccount, String accountName);
+    }
+
+    /**
+     * A container that holds metadata about an item view in the account list.
+     */
+    static class AccountViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
+
+        private boolean addAccount;
+        private final TextView textView;
+        private final AccountClickListener accountClickListener;
+
+        private AccountViewHolder(View itemView, AccountClickListener accountClickListener) {
+            super(itemView);
+            itemView.setOnClickListener(this);
+            textView = itemView.findViewById(R.id.accountTextView);
+            this.accountClickListener = accountClickListener;
+        }
+
+        /**
+         * Saves metadata about the item view and sets the item view's text.
+         * @param addAccount Indicates whether clicking this item view should initiate the process
+         *                   of adding a new account name.
+         * @param text The text to display in the item view.
+         */
+        private void bind(boolean addAccount, String text) {
+            this.addAccount = addAccount;
+            textView.setText(text);
+        }
+
+        @Override
+        public void onClick(View view) {
+            accountClickListener.onAccountClick(addAccount, textView.getText().toString());
+        }
+    }
+
+    private List<Account> accounts;
+    private AccountClickListener accountClickListener;
+
+    private AccountListAdapter(AccountClickListener accountClickListener) {
+        this.accountClickListener = accountClickListener;
+    }
+
+    /**
+     * Creates a new AccountListAdapter.
+     * @param accountClickListener The listener to invoke when an account is clicked.
+     * @return A new AccountListAdapter.
+     */
+    static AccountListAdapter create(AccountClickListener accountClickListener) {
+        return new AccountListAdapter(accountClickListener);
+    }
+
+    /**
+     * Sets the adapter's list of accounts to a copy of the provided account list.
+     * @param accounts The list of accounts to copy.
+     */
+    public void setAccounts(List<Account> accounts) {
+        this.accounts = new ArrayList<>(accounts);
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public AccountViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.account_list_item,
+                parent, false);
+        return new AccountViewHolder(itemView, accountClickListener);
+    }
+
+    @Override
+    public void onBindViewHolder(AccountViewHolder holder, int position) {
+        if (position < accounts.size()) {
+            holder.bind(false, accounts.get(position).name);
+        } else {
+            holder.bind(true, "Add Account");
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        if (accounts == null) {
+            return 0;
+        }
+        // Add one extra item for the Add Account item
+        return accounts.size() + 1;
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
@@ -1,0 +1,59 @@
+package com.google.moviestvsentiments.usecase.signin;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.lifecycle.Observer;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import android.os.Bundle;
+import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.model.Account;
+import com.google.moviestvsentiments.service.account.AccountViewModel;
+import dagger.hilt.android.AndroidEntryPoint;
+import java.util.List;
+import javax.inject.Inject;
+
+/**
+ * An Activity that displays a list of account names and allows for the selection of an existing
+ * account or the creation of a new account.
+ */
+@AndroidEntryPoint
+public class SigninActivity extends AppCompatActivity implements AccountListAdapter.AccountClickListener {
+
+    @Inject
+    AccountViewModel viewModel;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_signin);
+
+        RecyclerView accountList = findViewById(R.id.accountList);
+        accountList.setHasFixedSize(true);
+        final AccountListAdapter adapter = AccountListAdapter.create(this);
+        accountList.setAdapter(adapter);
+        accountList.setLayoutManager(new LinearLayoutManager(this));
+
+        viewModel.getAlphabetizedAccounts().observe(this, new Observer<List<Account>>() {
+            @Override
+            public void onChanged(List<Account> accounts) {
+                adapter.setAccounts(accounts);
+            }
+        });
+    }
+
+    /**
+     * Initiates the add account process if addAccount is true or sets the selected account to be
+     * the current account if addAccount is false.
+     * @param addAccount True if the user has requested to add a new account. False if the user
+     *                   has selected an existing account.
+     * @param accountName The name of the selected account or "Add Account" if addAccount is true.
+     */
+    @Override
+    public void onAccountClick(boolean addAccount, String accountName) {
+        if (!addAccount) {
+            viewModel.setIsCurrent(accountName, true);
+        } else {
+            viewModel.addAccount("Test Account");
+        }
+    }
+}


### PR DESCRIPTION
Adds a basic SigninActivity and integration tests. The SigninActivity currently displays the account names and can add a single, hardcoded account named "Test Account" when the Add Account button is pushed. This is used for the integration tests and will be changed to trigger an intent to the AddAccountActivity in a future pull request.