### PR TITLE
Add design of AddAccountActivity and launch it from SigninActivity

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -30,7 +30,7 @@ android {
     sourceSets {
         main {
             res {
-                srcDirs 'src/main/res', 'src/main/res/layouts/signin'
+                srcDirs 'src/main/res', 'src/main/res/layouts/signin', 'src/main/res/layouts/addAccount'
             }
         }
         androidTest.java.srcDirs += "src/test-common/java"
@@ -77,6 +77,7 @@ dependencies {
     // Testing
     androidTestImplementation "androidx.test:rules:1.1.0"
     androidTestImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.1.0'
     androidTestImplementation 'androidx.test.ext:truth:1.0.0'
     androidTestImplementation "com.google.truth:truth:$rootProject.truthVersion"
     testImplementation "org.mockito:mockito-core:1.10.19"

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
@@ -3,10 +3,10 @@ package com.google.moviestvsentiments.usecase.signin;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.not;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,9 +14,10 @@ import org.junit.rules.RuleChain;
 import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
 import dagger.hilt.android.testing.UninstallModules;
-import androidx.test.rule.ActivityTestRule;
+import androidx.test.espresso.intent.rule.IntentsTestRule;
 import com.google.moviestvsentiments.R;
 import com.google.moviestvsentiments.di.DatabaseModule;
+import com.google.moviestvsentiments.usecase.addAccount.AddAccountActivity;
 
 @UninstallModules(DatabaseModule.class)
 @HiltAndroidTest
@@ -24,7 +25,7 @@ public class SigninActivityTest {
 
     @Rule
     public RuleChain rule = RuleChain.outerRule(new HiltAndroidRule(this))
-            .around(new ActivityTestRule<>(SigninActivity.class));
+            .around(new IntentsTestRule<>(SigninActivity.class));
 
     @Test
     public void signinActivity_displaysOnlyAddAccount() {
@@ -32,10 +33,9 @@ public class SigninActivityTest {
     }
 
     @Test
-    public void signinActivity_clickAddAccount_addsAccount() {
+    public void signinActivity_clickAddAccount_sendsIntentToAddAccountActivity() {
         onView(withId(R.id.accountTextView)).perform(click());
 
-        onView(allOf(withId(R.id.accountTextView), not(withText("Add Account"))))
-                .check(matches(withText("Test Account")));
+        intended(hasComponent(AddAccountActivity.class.getName()));
     }
 }

--- a/MoviesTVSentiments/app/src/main/AndroidManifest.xml
+++ b/MoviesTVSentiments/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <activity android:name=".usecase.addAccount.AddAccountActivity"></activity>
         <activity android:name=".usecase.signin.SigninActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/addAccount/AddAccountActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/addAccount/AddAccountActivity.java
@@ -1,0 +1,14 @@
+package com.google.moviestvsentiments.usecase.addAccount;
+
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+import com.google.moviestvsentiments.R;
+
+public class AddAccountActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_add_account);
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
@@ -4,10 +4,14 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.Observer;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+
+import android.content.Intent;
 import android.os.Bundle;
 import com.google.moviestvsentiments.R;
 import com.google.moviestvsentiments.model.Account;
 import com.google.moviestvsentiments.service.account.AccountViewModel;
+import com.google.moviestvsentiments.usecase.addAccount.AddAccountActivity;
+
 import dagger.hilt.android.AndroidEntryPoint;
 import java.util.List;
 import javax.inject.Inject;
@@ -18,6 +22,8 @@ import javax.inject.Inject;
  */
 @AndroidEntryPoint
 public class SigninActivity extends AppCompatActivity implements AccountListAdapter.AccountClickListener {
+
+    private static final int ADD_ACCOUNT_REQUEST_CODE = 1;
 
     @Inject
     AccountViewModel viewModel;
@@ -53,7 +59,8 @@ public class SigninActivity extends AppCompatActivity implements AccountListAdap
         if (!addAccount) {
             viewModel.setIsCurrent(accountName, true);
         } else {
-            viewModel.addAccount("Test Account");
+            Intent intent = new Intent(this, AddAccountActivity.class);
+            startActivityForResult(intent, ADD_ACCOUNT_REQUEST_CODE);
         }
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
@@ -4,14 +4,12 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.Observer;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-
 import android.content.Intent;
 import android.os.Bundle;
 import com.google.moviestvsentiments.R;
 import com.google.moviestvsentiments.model.Account;
 import com.google.moviestvsentiments.service.account.AccountViewModel;
 import com.google.moviestvsentiments.usecase.addAccount.AddAccountActivity;
-
 import dagger.hilt.android.AndroidEntryPoint;
 import java.util.List;
 import javax.inject.Inject;

--- a/MoviesTVSentiments/app/src/main/res/layouts/addAccount/layout/activity_add_account.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/addAccount/layout/activity_add_account.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".usecase.addAccount.AddAccount">
+
+    <EditText
+        android:id="@+id/editAccountName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/bigPadding"
+        android:fontFamily="sans-serif-light"
+        android:hint="@string/addAccountHint"
+        android:inputType="textPersonName"
+        android:textSize="18sp"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:layout_editor_absoluteX="@dimen/bigPadding"
+        android:autofillHints="personName" />
+
+    <Button
+        android:id="@+id/addAccountButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/bigPadding"
+        android:background="@color/colorPrimary"
+        android:text="@string/addAccountSave"
+        android:textColor="@color/addAccountButtonText"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/editAccountName" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/MoviesTVSentiments/app/src/main/res/values/colors.xml
+++ b/MoviesTVSentiments/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="colorPrimary">#6200EE</color>
     <color name="colorPrimaryDark">#3700B3</color>
     <color name="colorAccent">#03DAC5</color>
+    <color name="addAccountButtonText">#FFFFFF</color>
 </resources>

--- a/MoviesTVSentiments/app/src/main/res/values/colors.xml
+++ b/MoviesTVSentiments/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#6200EE</color>
-    <color name="colorPrimaryDark">#3700B3</color>
-    <color name="colorAccent">#03DAC5</color>
+    <color name="colorPrimary">#FF1744</color>
+    <color name="colorPrimaryDark">#D60B41</color>
+    <color name="colorAccent">#FF1744</color>
     <color name="addAccountButtonText">#FFFFFF</color>
 </resources>

--- a/MoviesTVSentiments/app/src/main/res/values/dimens.xml
+++ b/MoviesTVSentiments/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="bigPadding">16dp</dimen>
+</resources>

--- a/MoviesTVSentiments/app/src/main/res/values/strings.xml
+++ b/MoviesTVSentiments/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Movies &amp; TV Sentiments</string>
+    <string name="addAccountHint">Account Name</string>
+    <string name="addAccountSave">Add Account</string>
 </resources>


### PR DESCRIPTION
Adds the layout file for the AddAccountActivity and starts the AddAccountActivity when the "Add Account" button is clicked in the SigninActivity. 

Screenshot of the AddAccount layout:
![addAccountLayout](https://user-images.githubusercontent.com/22841845/85175926-3b402f00-b23e-11ea-8caa-291cb08feae3.png)
