### PR TITLE
Add new accounts to the Room database

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     androidTestImplementation "androidx.test:rules:1.1.0"
     androidTestImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.2.0'
     androidTestImplementation 'androidx.test.ext:truth:1.0.0'
     androidTestImplementation "com.google.truth:truth:$rootProject.truthVersion"
     testImplementation "org.mockito:mockito-core:1.10.19"

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/assertions/RecyclerViewItemCountAssertion.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/assertions/RecyclerViewItemCountAssertion.java
@@ -1,0 +1,39 @@
+package com.google.moviestvsentiments.assertions;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.view.View;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.espresso.ViewAssertion;
+
+/**
+ * A ViewAssertion that checks the number of items in a RecyclerView.
+ */
+public class RecyclerViewItemCountAssertion implements ViewAssertion {
+
+    private final int expectedCount;
+
+    private RecyclerViewItemCountAssertion(int expectedCount) {
+        this.expectedCount = expectedCount;
+    }
+
+    /**
+     * Returns a new RecyclerViewItemCountAssertion that checks for the given number of items.
+     * @param expectedCount The expected number of items.
+     * @return A new RecyclerViewItemCountAssertion that checks for the given number of items.
+     */
+    public static RecyclerViewItemCountAssertion withItemCount(int expectedCount) {
+        return new RecyclerViewItemCountAssertion(expectedCount);
+    }
+
+    @Override
+    public void check(View view, NoMatchingViewException noViewFoundException) {
+        if (noViewFoundException != null) {
+            throw noViewFoundException;
+        }
+        RecyclerView recyclerView = (RecyclerView) view;
+        RecyclerView.Adapter adapter = recyclerView.getAdapter();
+        assertThat(adapter.getItemCount()).isEqualTo(expectedCount);
+    }
+}

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/addAccount/AddAccountActivityTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/addAccount/AddAccountActivityTest.java
@@ -1,0 +1,55 @@
+package com.google.moviestvsentiments.usecase.addAccount;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.contrib.ActivityResultMatchers.hasResultCode;
+import static androidx.test.espresso.contrib.ActivityResultMatchers.hasResultData;
+import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
+import static androidx.test.espresso.matcher.ViewMatchers.withHint;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+import android.app.Activity;
+import androidx.test.espresso.intent.matcher.IntentMatchers;
+import androidx.test.espresso.intent.rule.IntentsTestRule;
+import com.google.moviestvsentiments.R;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AddAccountActivityTest {
+
+    @Rule
+    public IntentsTestRule<AddAccountActivity> rule = new IntentsTestRule<>(AddAccountActivity.class);
+
+    @Test
+    public void addAccountActivity_editTextDisplaysPlaceholderText() {
+        onView(withId(R.id.editAccountName)).check(matches(withHint("Account Name")));
+    }
+
+    @Test
+    public void addAccountActivity_addButtonDisplaysText() {
+        onView(withId(R.id.addAccountButton)).check(matches(withText("Add Account")));
+    }
+
+    @Test
+    public void addAccountActivity_emptyText_sendsResultCanceled() {
+        onView(withId(R.id.addAccountButton)).perform(click());
+
+        assertThat(rule.getActivityResult(), hasResultCode(Activity.RESULT_CANCELED));
+    }
+
+    @Test
+    public void addAccountActivity_withText_sendsText() {
+        onView(withId(R.id.editAccountName)).perform(typeText("Test Account"),
+                closeSoftKeyboard());
+
+        onView(withId(R.id.addAccountButton)).perform(click());
+
+        assertThat(rule.getActivityResult(), hasResultCode(Activity.RESULT_OK));
+        assertThat(rule.getActivityResult(), hasResultData(IntentMatchers.hasExtra(
+                AddAccountActivity.EXTRA_ACCOUNT_NAME, "Test Account")));
+    }
+}

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
@@ -4,10 +4,15 @@ import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.Intents.intending;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static com.google.moviestvsentiments.assertions.RecyclerViewItemCountAssertion.withItemCount;
 
+import android.app.Activity;
+import android.app.Instrumentation.ActivityResult;
+import android.content.Intent;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -29,6 +34,7 @@ public class SigninActivityTest {
 
     @Test
     public void signinActivity_displaysOnlyAddAccount() {
+        onView(withId(R.id.accountList)).check(withItemCount(1));
         onView(withId(R.id.accountTextView)).check(matches(withText("Add Account")));
     }
 
@@ -37,5 +43,28 @@ public class SigninActivityTest {
         onView(withId(R.id.accountTextView)).perform(click());
 
         intended(hasComponent(AddAccountActivity.class.getName()));
+    }
+
+    @Test
+    public void signinActivity_addAccountResultCanceled_displaysOnlyAddAccount() {
+        ActivityResult result = new ActivityResult(Activity.RESULT_CANCELED, new Intent());
+        intending(hasComponent(AddAccountActivity.class.getName())).respondWith(result);
+
+        onView(withId(R.id.accountTextView)).perform(click());
+
+        onView(withId(R.id.accountList)).check(withItemCount(1));
+        onView(withId(R.id.accountTextView)).check(matches(withText("Add Account")));
+    }
+
+    @Test
+    public void signinActivity_addAccountResultOk_displaysNewAccount() {
+        Intent intent = new Intent();
+        intent.putExtra(AddAccountActivity.EXTRA_ACCOUNT_NAME, "Account Name");
+        ActivityResult result = new ActivityResult(Activity.RESULT_OK, intent);
+        intending(hasComponent(AddAccountActivity.class.getName())).respondWith(result);
+
+        onView(withId(R.id.accountTextView)).perform(click());
+
+        onView(withId(R.id.accountList)).check(withItemCount(2));
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/addAccount/AddAccountActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/addAccount/AddAccountActivity.java
@@ -1,14 +1,40 @@
 package com.google.moviestvsentiments.usecase.addAccount;
 
 import androidx.appcompat.app.AppCompatActivity;
+import android.content.Intent;
 import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
 import com.google.moviestvsentiments.R;
 
+/**
+ * An Activity that displays an editable text field for the creation of new accounts.
+ */
 public class AddAccountActivity extends AppCompatActivity {
+
+    public static final String EXTRA_ACCOUNT_NAME = "com.google.moviestvsentiments.ACCOUNT_NAME";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_add_account);
+
+        EditText editAccountName = findViewById(R.id.editAccountName);
+        Button addAccountButton = findViewById(R.id.addAccountButton);
+        addAccountButton.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View view) {
+                Intent replyIntent = new Intent();
+                if (TextUtils.isEmpty(editAccountName.getText())) {
+                    setResult(RESULT_CANCELED, replyIntent);
+                } else {
+                    String accountName = editAccountName.getText().toString();
+                    replyIntent.putExtra(EXTRA_ACCOUNT_NAME, accountName);
+                    setResult(RESULT_OK, replyIntent);
+                }
+                finish();
+            }
+        });
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
@@ -61,4 +61,21 @@ public class SigninActivity extends AppCompatActivity implements AccountListAdap
             startActivityForResult(intent, ADD_ACCOUNT_REQUEST_CODE);
         }
     }
+
+    /**
+     * Adds the account name returned by the AddAccountActivity to the Room database. If the
+     * result code is not RESULT_OK, then no change is made to the database.
+     * @param requestCode The request code used to start the AddAccountActivity.
+     * @param resultCode The result code returned by the AddAccountActivity.
+     * @param data The intent returned by the AddAccountActivity.
+     */
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == ADD_ACCOUNT_REQUEST_CODE && resultCode == RESULT_OK) {
+            String accountName = data.getStringExtra(AddAccountActivity.EXTRA_ACCOUNT_NAME);
+            viewModel.addAccount(accountName);
+        }
+    }
 }


### PR DESCRIPTION
Implements the functionality of the AddAccountActivity. The user's input is transferred in an intent to the SigninActivity, which passes the new account name to the AccountViewModel to insert it into the accounts Room table. Also adds tests for both the AddAccountActivity and SigninActivty to check both sides of this interaction.