### PR TITLE
Add basic bottom navigation activity

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -30,7 +30,7 @@ android {
     sourceSets {
         main {
             res {
-                srcDirs 'src/main/res', 'src/main/res/layouts/signin', 'src/main/res/layouts/addAccount'
+                srcDirs 'src/main/res', 'src/main/res/layouts/signin', 'src/main/res/layouts/addAccount', 'src/main/res/layouts/disliked', 'src/main/res/layouts/liked', 'src/main/res/layouts/home', 'src/main/res/layouts/navigation'
             }
         }
         androidTest.java.srcDirs += "src/test-common/java"
@@ -51,6 +51,10 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'androidx.vectordrawable:vectordrawable:1.1.0'
+    implementation 'androidx.navigation:navigation-fragment:2.1.0'
+    implementation 'androidx.navigation:navigation-ui:2.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/MoviesTVSentiments/app/src/main/AndroidManifest.xml
+++ b/MoviesTVSentiments/app/src/main/AndroidManifest.xml
@@ -10,13 +10,13 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".usecase.addAccount.AddAccountActivity"></activity>
+        <activity android:name=".usecase.navigation.SentimentsNavigationActivity" />
+        <activity android:name=".usecase.addAccount.AddAccountActivity" />
         <activity android:name=".usecase.signin.SigninActivity">
-            <intent-filter>
+             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+             </intent-filter>
         </activity>
     </application>
 

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/disliked/DislikedFragment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/disliked/DislikedFragment.java
@@ -1,0 +1,25 @@
+package com.google.moviestvsentiments.usecase.disliked;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import com.google.moviestvsentiments.R;
+
+/**
+ * A fragment that displays the list of disliked assets.
+ */
+public class DislikedFragment extends Fragment {
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_disliked, container, false);
+        final TextView textView = root.findViewById(R.id.text_disliked);
+        textView.setText("This is the disliked fragment.");
+        return root;
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/home/HomeFragment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/home/HomeFragment.java
@@ -1,0 +1,25 @@
+package com.google.moviestvsentiments.usecase.home;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import com.google.moviestvsentiments.R;
+
+/**
+ * A fragment that displays the list of assets that have not been reacted to.
+ */
+public class HomeFragment extends Fragment {
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_home, container, false);
+        final TextView textView = root.findViewById(R.id.text_home);
+        textView.setText("This is the home fragment.");
+        return root;
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/liked/LikedFragment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/liked/LikedFragment.java
@@ -1,0 +1,25 @@
+package com.google.moviestvsentiments.usecase.liked;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import com.google.moviestvsentiments.R;
+
+/**
+ * A fragment that displays the list of liked activities.
+ */
+public class LikedFragment extends Fragment {
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View root = inflater.inflate(R.layout.fragment_liked, container, false);
+        final TextView textView = root.findViewById(R.id.text_liked);
+        textView.setText("This is the liked fragment.");
+        return root;
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/navigation/SentimentsNavigationActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/navigation/SentimentsNavigationActivity.java
@@ -1,0 +1,31 @@
+package com.google.moviestvsentiments.usecase.navigation;
+
+import android.os.Bundle;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.moviestvsentiments.R;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
+import androidx.navigation.ui.AppBarConfiguration;
+import androidx.navigation.ui.NavigationUI;
+
+/**
+ * An activity that manages switching between the Home, Liked and Disliked tabs.
+ */
+public class SentimentsNavigationActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_sentiments_navigation);
+        BottomNavigationView navView = findViewById(R.id.nav_view);
+        // Passing each menu ID as a set of Ids because each
+        // menu should be considered as top level destinations.
+        AppBarConfiguration appBarConfiguration = new AppBarConfiguration.Builder(
+                R.id.navigation_home, R.id.navigation_liked, R.id.navigation_disliked)
+                .build();
+        NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment);
+        NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
+        NavigationUI.setupWithNavController(navView, navController);
+    }
+}

--- a/MoviesTVSentiments/app/src/main/res/drawable/ic_baseline_home_24.xml
+++ b/MoviesTVSentiments/app/src/main/res/drawable/ic_baseline_home_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
+</vector>

--- a/MoviesTVSentiments/app/src/main/res/drawable/ic_baseline_thumb_down_24.xml
+++ b/MoviesTVSentiments/app/src/main/res/drawable/ic_baseline_thumb_down_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15,3L6,3c-0.83,0 -1.54,0.5 -1.84,1.22l-3.02,7.05c-0.09,0.23 -0.14,0.47 -0.14,0.73v2c0,1.1 0.9,2 2,2h6.31l-0.95,4.57 -0.03,0.32c0,0.41 0.17,0.79 0.44,1.06L9.83,23l6.59,-6.59c0.36,-0.36 0.58,-0.86 0.58,-1.41L17,5c0,-1.1 -0.9,-2 -2,-2zM19,3v12h4L23,3h-4z"/>
+</vector>

--- a/MoviesTVSentiments/app/src/main/res/drawable/ic_baseline_thumb_up_24.xml
+++ b/MoviesTVSentiments/app/src/main/res/drawable/ic_baseline_thumb_up_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M1,21h4L5,9L1,9v12zM23,10c0,-1.1 -0.9,-2 -2,-2h-6.31l0.95,-4.57 0.03,-0.32c0,-0.41 -0.17,-0.79 -0.44,-1.06L14.17,1 7.59,7.59C7.22,7.95 7,8.45 7,9v10c0,1.1 0.9,2 2,2h9c0.83,0 1.54,-0.5 1.84,-1.22l3.02,-7.05c0.09,-0.23 0.14,-0.47 0.14,-0.73v-2z"/>
+</vector>

--- a/MoviesTVSentiments/app/src/main/res/layouts/disliked/layout/fragment_disliked.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/disliked/layout/fragment_disliked.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".usecase.disliked.DislikedFragment">
+
+    <TextView
+        android:id="@+id/text_disliked"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:textAlignment="center"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/MoviesTVSentiments/app/src/main/res/layouts/home/layout/fragment_home.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/home/layout/fragment_home.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".usecase.home.HomeFragment">
+
+    <TextView
+        android:id="@+id/text_home"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:textAlignment="center"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/MoviesTVSentiments/app/src/main/res/layouts/liked/layout/fragment_liked.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/liked/layout/fragment_liked.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".usecase.liked.LikedFragment">
+
+    <TextView
+        android:id="@+id/text_liked"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:textSize="20sp"
+        android:textAlignment="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/MoviesTVSentiments/app/src/main/res/layouts/navigation/layout/activity_sentiments_navigation.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/navigation/layout/activity_sentiments_navigation.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="?attr/actionBarSize">
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/nav_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="0dp"
+        android:layout_marginEnd="0dp"
+        android:background="?android:attr/windowBackground"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:menu="@menu/bottom_nav_menu" />
+
+    <fragment
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toTopOf="@id/nav_view"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/mobile_navigation" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/MoviesTVSentiments/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/MoviesTVSentiments/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/navigation_home"
+        android:icon="@drawable/ic_baseline_home_24"
+        android:title="@string/title_home" />
+
+    <item
+        android:id="@+id/navigation_liked"
+        android:icon="@drawable/ic_baseline_thumb_up_24"
+        android:title="@string/title_liked" />
+
+    <item
+        android:id="@+id/navigation_disliked"
+        android:icon="@drawable/ic_baseline_thumb_down_24"
+        android:title="@string/title_disliked" />
+
+</menu>

--- a/MoviesTVSentiments/app/src/main/res/navigation/mobile_navigation.xml
+++ b/MoviesTVSentiments/app/src/main/res/navigation/mobile_navigation.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/mobile_navigation"
+    app:startDestination="@+id/navigation_home">
+
+    <fragment
+        android:id="@+id/navigation_home"
+        android:name="com.google.moviestvsentiments.usecase.home.HomeFragment"
+        android:label="@string/title_home"
+        tools:layout="@layout/fragment_home" />
+
+    <fragment
+        android:id="@+id/navigation_liked"
+        android:name="com.google.moviestvsentiments.usecase.liked.LikedFragment"
+        android:label="@string/title_liked"
+        tools:layout="@layout/fragment_liked" />
+
+    <fragment
+        android:id="@+id/navigation_disliked"
+        android:name="com.google.moviestvsentiments.usecase.disliked.DislikedFragment"
+        android:label="@string/title_disliked"
+        tools:layout="@layout/fragment_disliked" />
+</navigation>

--- a/MoviesTVSentiments/app/src/main/res/values/strings.xml
+++ b/MoviesTVSentiments/app/src/main/res/values/strings.xml
@@ -2,4 +2,7 @@
     <string name="app_name">Movies &amp; TV Sentiments</string>
     <string name="addAccountHint">Account Name</string>
     <string name="addAccountSave">Add Account</string>
+    <string name="title_home">Home</string>
+    <string name="title_liked">Liked</string>
+    <string name="title_disliked">Disliked</string>
 </resources>


### PR DESCRIPTION
Adds a basic bottom navigation activity created using the Android Studio new activity templates. Strings and file locations were then changed to match the Movies and TV Sentiments app. The new activity/fragments currently just display a single text view identifying the selected tab. Actual functionality will be added in future pull requests.

<img width="340" alt="Screen Shot 2020-06-22 at 1 13 00 PM" src="https://user-images.githubusercontent.com/22841845/85323198-38874900-b48d-11ea-98dc-c96a741144b5.png">
<img width="343" alt="Screen Shot 2020-06-22 at 1 13 08 PM" src="https://user-images.githubusercontent.com/22841845/85323204-3a510c80-b48d-11ea-883d-ee7ab2ce1a70.png">
<img width="342" alt="Screen Shot 2020-06-22 at 1 12 49 PM" src="https://user-images.githubusercontent.com/22841845/85323205-3ae9a300-b48d-11ea-8a0a-50a50f30c734.png">
