### PR TITLE
Add layout files for asset lists and items

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -30,7 +30,7 @@ android {
     sourceSets {
         main {
             res {
-                srcDirs 'src/main/res', 'src/main/res/layouts/signin', 'src/main/res/layouts/addAccount', 'src/main/res/layouts/disliked', 'src/main/res/layouts/liked', 'src/main/res/layouts/home', 'src/main/res/layouts/navigation'
+                srcDirs 'src/main/res', 'src/main/res/layouts/signin', 'src/main/res/layouts/addAccount', 'src/main/res/layouts/disliked', 'src/main/res/layouts/liked', 'src/main/res/layouts/home', 'src/main/res/layouts/navigation', 'src/main/res/layouts/assetList'
             }
         }
         androidTest.java.srcDirs += "src/test-common/java"

--- a/MoviesTVSentiments/app/src/main/res/layouts/assetList/layout/asset_list_item.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/assetList/layout/asset_list_item.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/asset_card"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="@dimen/bigPadding">
+
+        <ImageView
+            android:id="@+id/asset_card_image"
+            android:layout_width="135dp"
+            android:layout_height="200dp"
+            android:scaleType="centerCrop" />
+
+
+    </androidx.cardview.widget.CardView>
+
+</LinearLayout>

--- a/MoviesTVSentiments/app/src/main/res/layouts/assetList/layout/asset_lists_screen.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/assetList/layout/asset_lists_screen.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".usecase.home.HomeFragment">
+
+    <TextView
+        android:id="@+id/movies_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/bigPadding"
+        android:layout_marginTop="@dimen/bigPadding"
+        android:text="@string/movies_label"
+        android:textSize="@dimen/title_font_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/movies_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/bigPadding"
+        android:paddingLeft="@dimen/bigPadding"
+        android:clipToPadding="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/movies_label" />
+
+    <TextView
+        android:id="@+id/tvshows_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/bigPadding"
+        android:layout_marginTop="@dimen/bigPadding"
+        android:text="@string/tvshows_label"
+        android:textSize="@dimen/title_font_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/movies_list" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/tvshows_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/bigPadding"
+        android:paddingLeft="@dimen/bigPadding"
+        android:clipToPadding="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tvshows_label" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/MoviesTVSentiments/app/src/main/res/layouts/navigation/layout/activity_sentiments_navigation.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/navigation/layout/activity_sentiments_navigation.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingTop="?attr/actionBarSize">
+    android:layout_height="match_parent" >
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/nav_view"

--- a/MoviesTVSentiments/app/src/main/res/values/dimens.xml
+++ b/MoviesTVSentiments/app/src/main/res/values/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="bigPadding">16dp</dimen>
+    <dimen name="title_font_size">20sp</dimen>
 </resources>

--- a/MoviesTVSentiments/app/src/main/res/values/strings.xml
+++ b/MoviesTVSentiments/app/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
     <string name="title_home">Home</string>
     <string name="title_liked">Liked</string>
     <string name="title_disliked">Disliked</string>
+    <string name="movies_label">Movies</string>
+    <string name="tvshows_label">TV Shows</string>
 </resources>


### PR DESCRIPTION
Adds the layout files for the list of assets. The layout looks like this:

<img width="338" alt="Screen Shot 2020-06-23 at 3 04 16 PM" src="https://user-images.githubusercontent.com/22841845/85457735-ff6ed780-b565-11ea-9b32-07f881303b77.png">
