### PR TITLE
Switch to SentimentsNavigationActivity when current account is set

### DIFF
--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
@@ -6,9 +6,11 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.espresso.intent.Intents.intending;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.google.moviestvsentiments.assertions.RecyclerViewItemCountAssertion.withItemCount;
+import static org.hamcrest.Matchers.allOf;
 
 import android.app.Activity;
 import android.app.Instrumentation.ActivityResult;
@@ -23,6 +25,7 @@ import androidx.test.espresso.intent.rule.IntentsTestRule;
 import com.google.moviestvsentiments.R;
 import com.google.moviestvsentiments.di.DatabaseModule;
 import com.google.moviestvsentiments.usecase.addAccount.AddAccountActivity;
+import com.google.moviestvsentiments.usecase.navigation.SentimentsNavigationActivity;
 
 @UninstallModules(DatabaseModule.class)
 @HiltAndroidTest
@@ -66,5 +69,19 @@ public class SigninActivityTest {
         onView(withId(R.id.accountTextView)).perform(click());
 
         onView(withId(R.id.accountList)).check(withItemCount(2));
+    }
+
+    @Test
+    public void signinActivity_clickAccountName_sendsIntentToSentimentsNavigationActivity() {
+        Intent intent = new Intent();
+        intent.putExtra(AddAccountActivity.EXTRA_ACCOUNT_NAME, "Account Name");
+        ActivityResult result = new ActivityResult(Activity.RESULT_OK, intent);
+        intending(hasComponent(AddAccountActivity.class.getName())).respondWith(result);
+        onView(withId(R.id.accountTextView)).perform(click());
+
+        onView(allOf(withId(R.id.accountTextView), withText("Account Name"))).perform(click());
+
+        intended(allOf(hasComponent(SentimentsNavigationActivity.class.getName()),
+                hasExtra(SigninActivity.EXTRA_ACCOUNT_NAME, "Account Name")));
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
@@ -10,6 +10,7 @@ import com.google.moviestvsentiments.R;
 import com.google.moviestvsentiments.model.Account;
 import com.google.moviestvsentiments.service.account.AccountViewModel;
 import com.google.moviestvsentiments.usecase.addAccount.AddAccountActivity;
+import com.google.moviestvsentiments.usecase.navigation.SentimentsNavigationActivity;
 import dagger.hilt.android.AndroidEntryPoint;
 import java.util.List;
 import javax.inject.Inject;
@@ -21,6 +22,8 @@ import javax.inject.Inject;
 @AndroidEntryPoint
 public class SigninActivity extends AppCompatActivity implements AccountListAdapter.AccountClickListener {
 
+    public static final String EXTRA_ACCOUNT_NAME = "com.google.moviestvsentiments.ACCOUNT_NAME";
+
     private static final int ADD_ACCOUNT_REQUEST_CODE = 1;
 
     @Inject
@@ -30,6 +33,15 @@ public class SigninActivity extends AppCompatActivity implements AccountListAdap
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_signin);
+
+        viewModel.getCurrentAccount().observe(this, account -> {
+            if (account != null) {
+                Intent intent = new Intent(this, SentimentsNavigationActivity.class);
+                intent.putExtra(EXTRA_ACCOUNT_NAME, account.name);
+                startActivity(intent);
+                finish();
+            }
+        });
 
         RecyclerView accountList = findViewById(R.id.accountList);
         accountList.setHasFixedSize(true);


### PR DESCRIPTION
Adds an observer to the AccountViewModel's getCurrentAccount() so that the SigninActivity will transition to the SentimentsNavigationActivity when the current account is set. Adds an integration test to check this functionality.