### PR TITLE
Display assets with no reaction in HomeFragment, add tests

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-extensions:$rootProject.archLifecycleVersion"
     annotationProcessor "androidx.lifecycle:lifecycle-compiler:$rootProject.archLifecycleVersion"
 
+    // Glide
+    implementation "com.github.bumptech.glide:glide:4.11.0"
+
     // Testing
     androidTestImplementation "androidx.test:rules:1.1.0"
     androidTestImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/HiltFragmentScenario.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/HiltFragmentScenario.java
@@ -1,0 +1,43 @@
+package com.google.moviestvsentiments;
+
+import android.content.Intent;
+import androidx.fragment.app.Fragment;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+
+/**
+ * HiltFragmentScenario provides an API to launch fragments that use Hilt for dependency injection.
+ */
+public class HiltFragmentScenario {
+
+    /**
+     * Launches a fragment hosted by an empty HiltTestActivity.
+     * @param fragmentClass The class of the fragment to instantiate.
+     * @param <F> The type of the fragment.
+     */
+    public static <F extends Fragment> void launchHiltFragment(Class<F> fragmentClass) {
+        Intent intent = new Intent(ApplicationProvider.getApplicationContext(),
+                HiltTestActivity.class);
+        launchHiltFragmentWithIntent(fragmentClass, intent);
+    }
+
+    /**
+     * Launches a fragment using the provided intent. This method allows for launching the fragment
+     * using activities other than HiltTestActivity or with intent extras.
+     * @param fragmentClass The class of the fragment to instantiate.
+     * @param intent The intent to use when launching the hosting activity.
+     * @param <F> The type of the fragment.
+     */
+    public static <F extends Fragment> void launchHiltFragmentWithIntent(Class<F> fragmentClass,
+                                                                         Intent intent) {
+        ActivityScenario<HiltTestActivity> activityScenario = ActivityScenario.launch(intent);
+        activityScenario.onActivity(activity -> {
+            Fragment fragment = activity.getSupportFragmentManager().getFragmentFactory()
+                    .instantiate(fragmentClass.getClassLoader(), fragmentClass.getName());
+            activity.getSupportFragmentManager()
+                    .beginTransaction()
+                    .add(android.R.id.content, fragment, null)
+                    .commitNow();
+        });
+    }
+}

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDaoTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDaoTest.java
@@ -12,6 +12,7 @@ import com.google.moviestvsentiments.model.AssetSentiment;
 import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
 import com.google.moviestvsentiments.service.database.SentimentsDatabase;
+import com.google.moviestvsentiments.util.AssetUtil;
 import com.google.moviestvsentiments.util.LiveDataTestUtil;
 import org.junit.After;
 import org.junit.Before;
@@ -23,14 +24,8 @@ import java.util.List;
 @RunWith(AndroidJUnit4.class)
 public class AssetSentimentDaoTest {
 
-    private static final Asset MOVIE_ASSET = createMovieAsset("assetId");
-    private static final Asset MOVIE_ASSET_2 = createMovieAsset("assetId2");
-
-    private static Asset createMovieAsset(String assetId) {
-        return Asset.builder().setId(assetId).setType(AssetType.MOVIE).setTitle("assetTitle")
-                .setPoster("posterURL").setBanner("bannerURL").setPlot("plotDescription")
-                .setRuntime("runtime").setYear("year").setTimestamp(1).build();
-    }
+    private static final Asset MOVIE_ASSET = AssetUtil.createMovieAsset("assetId");
+    private static final Asset MOVIE_ASSET_2 = AssetUtil.createMovieAsset("assetId2");
 
     @Rule
     public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/home/HomeFragmentTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/home/HomeFragmentTest.java
@@ -1,0 +1,98 @@
+package com.google.moviestvsentiments.usecase.home;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static com.google.moviestvsentiments.assertions.RecyclerViewItemCountAssertion.withItemCount;
+
+import android.content.Intent;
+import androidx.test.core.app.ApplicationProvider;
+import com.google.moviestvsentiments.HiltTestActivity;
+import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.di.DatabaseModule;
+import com.google.moviestvsentiments.model.Asset;
+import com.google.moviestvsentiments.model.AssetType;
+import com.google.moviestvsentiments.model.SentimentType;
+import com.google.moviestvsentiments.service.database.SentimentsDatabase;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import javax.inject.Inject;
+import dagger.hilt.android.testing.HiltAndroidRule;
+import dagger.hilt.android.testing.HiltAndroidTest;
+import dagger.hilt.android.testing.UninstallModules;
+import com.google.moviestvsentiments.HiltFragmentScenario;
+import com.google.moviestvsentiments.usecase.signin.SigninActivity;
+
+@UninstallModules(DatabaseModule.class)
+@HiltAndroidTest
+public class HomeFragmentTest {
+
+    private static Asset createMovieAsset(String assetId) {
+        return Asset.builder().setId(assetId).setType(AssetType.MOVIE).setTitle("assetTitle")
+                .setPoster("posterURL").setBanner("bannerURL").setPlot("plotDescription")
+                .setRuntime("runtime").setYear("year").setTimestamp(1).build();
+    }
+
+    @Rule
+    public HiltAndroidRule hiltAndroidRule = new HiltAndroidRule(this);
+
+    @Inject
+    SentimentsDatabase database;
+
+    @Before
+    public void setUp() {
+        hiltAndroidRule.inject();
+    }
+
+    @Test
+    public void homeFragment_startsWithEmptyMovieList() {
+        HiltFragmentScenario.launchHiltFragment(HomeFragment.class);
+
+        onView(withId(R.id.movies_list)).check(withItemCount(0));
+    }
+
+    @Test
+    public void homeFragment_startsWithEmptyShowList() {
+        HiltFragmentScenario.launchHiltFragment(HomeFragment.class);
+
+        onView(withId(R.id.tvshows_list)).check(withItemCount(0));
+    }
+
+    @Test
+    public void homeFragment_displaysAssetsWithNoReaction() {
+        database.assetSentimentDao().addAsset(createMovieAsset("assetId1"));
+
+        HiltFragmentScenario.launchHiltFragment(HomeFragment.class);
+
+        onView(withId(R.id.movies_list)).check(withItemCount(1));
+    }
+
+    @Test
+    public void homeFragment_displaysAssetsWithUnspecifiedReaction() {
+        database.assetSentimentDao().addAsset(createMovieAsset("assetId1"));
+        database.assetSentimentDao().updateSentiment("Test Account", "assetId1",
+                AssetType.MOVIE, SentimentType.UNSPECIFIED);
+        Intent intent = new Intent(ApplicationProvider.getApplicationContext(), HiltTestActivity.class);
+        intent.putExtra(SigninActivity.EXTRA_ACCOUNT_NAME, "Test Account");
+
+        HiltFragmentScenario.launchHiltFragmentWithIntent(HomeFragment.class, intent);
+
+        onView(withId(R.id.movies_list)).check(withItemCount(1));
+    }
+
+    @Test
+    public void homeFragment_ignoresAssetsWithReaction() {
+        database.assetSentimentDao().addAsset(createMovieAsset("assetId1"));
+        database.assetSentimentDao().addAsset(createMovieAsset("assetId2"));
+        database.assetSentimentDao().updateSentiment("Test Account", "assetId1",
+                AssetType.MOVIE, SentimentType.THUMBS_UP);
+        database.assetSentimentDao().updateSentiment("Test Account", "assetId2",
+                AssetType.MOVIE, SentimentType.THUMBS_DOWN);
+        Intent intent = new Intent(ApplicationProvider.getApplicationContext(), HiltTestActivity.class);
+        intent.putExtra(SigninActivity.EXTRA_ACCOUNT_NAME, "Test Account");
+
+        HiltFragmentScenario.launchHiltFragmentWithIntent(HomeFragment.class, intent);
+
+        onView(withId(R.id.movies_list)).check(withItemCount(0));
+    }
+}

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/home/HomeFragmentTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/home/HomeFragmentTest.java
@@ -9,7 +9,6 @@ import androidx.test.core.app.ApplicationProvider;
 import com.google.moviestvsentiments.HiltTestActivity;
 import com.google.moviestvsentiments.R;
 import com.google.moviestvsentiments.di.DatabaseModule;
-import com.google.moviestvsentiments.model.Asset;
 import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
 import com.google.moviestvsentiments.service.database.SentimentsDatabase;
@@ -22,16 +21,11 @@ import dagger.hilt.android.testing.HiltAndroidTest;
 import dagger.hilt.android.testing.UninstallModules;
 import com.google.moviestvsentiments.HiltFragmentScenario;
 import com.google.moviestvsentiments.usecase.signin.SigninActivity;
+import com.google.moviestvsentiments.util.AssetUtil;
 
 @UninstallModules(DatabaseModule.class)
 @HiltAndroidTest
 public class HomeFragmentTest {
-
-    private static Asset createMovieAsset(String assetId) {
-        return Asset.builder().setId(assetId).setType(AssetType.MOVIE).setTitle("assetTitle")
-                .setPoster("posterURL").setBanner("bannerURL").setPlot("plotDescription")
-                .setRuntime("runtime").setYear("year").setTimestamp(1).build();
-    }
 
     @Rule
     public HiltAndroidRule hiltAndroidRule = new HiltAndroidRule(this);
@@ -60,7 +54,7 @@ public class HomeFragmentTest {
 
     @Test
     public void homeFragment_displaysAssetsWithNoReaction() {
-        database.assetSentimentDao().addAsset(createMovieAsset("assetId1"));
+        database.assetSentimentDao().addAsset(AssetUtil.createMovieAsset("assetId1"));
 
         HiltFragmentScenario.launchHiltFragment(HomeFragment.class);
 
@@ -69,7 +63,7 @@ public class HomeFragmentTest {
 
     @Test
     public void homeFragment_displaysAssetsWithUnspecifiedReaction() {
-        database.assetSentimentDao().addAsset(createMovieAsset("assetId1"));
+        database.assetSentimentDao().addAsset(AssetUtil.createMovieAsset("assetId1"));
         database.assetSentimentDao().updateSentiment("Test Account", "assetId1",
                 AssetType.MOVIE, SentimentType.UNSPECIFIED);
         Intent intent = new Intent(ApplicationProvider.getApplicationContext(), HiltTestActivity.class);
@@ -82,8 +76,8 @@ public class HomeFragmentTest {
 
     @Test
     public void homeFragment_ignoresAssetsWithReaction() {
-        database.assetSentimentDao().addAsset(createMovieAsset("assetId1"));
-        database.assetSentimentDao().addAsset(createMovieAsset("assetId2"));
+        database.assetSentimentDao().addAsset(AssetUtil.createMovieAsset("assetId1"));
+        database.assetSentimentDao().addAsset(AssetUtil.createMovieAsset("assetId2"));
         database.assetSentimentDao().updateSentiment("Test Account", "assetId1",
                 AssetType.MOVIE, SentimentType.THUMBS_UP);
         database.assetSentimentDao().updateSentiment("Test Account", "assetId2",

--- a/MoviesTVSentiments/app/src/debug/AndroidManifest.xml
+++ b/MoviesTVSentiments/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.moviestvsentiments">
+
+    <application>
+        <activity
+            android:name=".HiltTestActivity"
+            android:exported="false"  />
+    </application>
+
+</manifest>

--- a/MoviesTVSentiments/app/src/debug/java/com/google/moviestvsentiments/HiltTestActivity.java
+++ b/MoviesTVSentiments/app/src/debug/java/com/google/moviestvsentiments/HiltTestActivity.java
@@ -1,0 +1,11 @@
+package com.google.moviestvsentiments;
+
+import androidx.appcompat.app.AppCompatActivity;
+import dagger.hilt.android.AndroidEntryPoint;
+
+/**
+ * An empty activity for use when hosting Hilt fragments in instrumented tests.
+ */
+@AndroidEntryPoint
+public class HiltTestActivity extends AppCompatActivity {
+}

--- a/MoviesTVSentiments/app/src/main/AndroidManifest.xml
+++ b/MoviesTVSentiments/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.moviestvsentiments">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".MoviesTVSentimentsApplication"
         android:allowBackup="true"

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/component/AssetListAdapter.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/component/AssetListAdapter.java
@@ -1,0 +1,83 @@
+package com.google.moviestvsentiments.usecase.component;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+import com.bumptech.glide.Glide;
+import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.model.AssetSentiment;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An adapter that binds a list of AssetSentiment objects to views for display in a RecyclerView.
+ * Only the asset poster images are displayed.
+ */
+public class AssetListAdapter extends RecyclerView.Adapter<AssetListAdapter.AssetViewHolder> {
+
+    /**
+     * A container that holds metadata about an item view in the asset list.
+     */
+    static class AssetViewHolder extends RecyclerView.ViewHolder {
+
+        private final ImageView imageView;
+
+        private AssetViewHolder(@NonNull View itemView) {
+            super(itemView);
+            imageView = itemView.findViewById(R.id.asset_card_image);
+        }
+
+        /**
+         * Loads the provided AssetSentiment's poster image into this AssetViewHolder's ImageView using
+         * Glide.
+         * @param assetSentiment The AssetSentiment whose poster image should be displayed in this
+         *                       AssetViewHolder.
+         */
+        private void bind(AssetSentiment assetSentiment) {
+            Glide.with(imageView).load(assetSentiment.asset().poster()).into(imageView);
+        }
+    }
+
+    private List<AssetSentiment> assetSentiments;
+
+    private AssetListAdapter() {
+        assetSentiments = new ArrayList<>();
+    }
+
+    /**
+     * Returns a new AssetListAdapter.
+     */
+    public static AssetListAdapter create() {
+        return new AssetListAdapter();
+    }
+
+    /**
+     * Sets the adapter's list of AssetSentiments to a copy of the provided AssetSentiment list.
+     * @param assetSentiments The list of AssetSentiments to copy.
+     */
+    public void setAssetSentiments(List<AssetSentiment> assetSentiments) {
+        this.assetSentiments = new ArrayList<>(assetSentiments);
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public AssetViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.asset_list_item,
+                parent, false);
+        return new AssetViewHolder(itemView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull AssetViewHolder holder, int position) {
+        holder.bind(assetSentiments.get(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return assetSentiments.size();
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/component/AssetListScreen.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/component/AssetListScreen.java
@@ -1,0 +1,64 @@
+package com.google.moviestvsentiments.usecase.component;
+
+import android.content.Context;
+import android.view.View;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.model.AssetSentiment;
+import java.util.List;
+
+/**
+ * A component that displays a list of movies and a list of TV shows.
+ */
+public class AssetListScreen {
+
+    private AssetListAdapter movieAdapter;
+    private AssetListAdapter showAdapter;
+
+    private AssetListScreen() {
+        movieAdapter = AssetListAdapter.create();
+        showAdapter = AssetListAdapter.create();
+    }
+
+    /**
+     * Creates a new AssetListScreen.
+     * @param root The root view where the AssetListScreen is displayed. It must contain recycler
+     *             views with the movies_list and the tvshows_list ids.
+     * @param context The context where the AssetListScreen is displayed.
+     * @return A new AssetListScreen.
+     */
+    public static AssetListScreen create(View root, Context context) {
+        AssetListScreen assetListScreen = new AssetListScreen();
+        assetListScreen.setupLists(root, context);
+        return assetListScreen;
+    }
+
+    private void setupLists(View root, Context context) {
+        RecyclerView movieList = root.findViewById(R.id.movies_list);
+        movieList.setAdapter(movieAdapter);
+        movieList.setLayoutManager(new LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL,
+                false));
+
+        RecyclerView showList = root.findViewById(R.id.tvshows_list);
+        showList.setAdapter(showAdapter);
+        showList.setLayoutManager(new LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL,
+                false));
+    }
+
+    /**
+     * Sets the displayed list of movies.
+     * @param movies The list of movies to display.
+     */
+    public void setMovies(List<AssetSentiment> movies) {
+        movieAdapter.setAssetSentiments(movies);
+    }
+
+    /**
+     * Sets the displayed list of TV shows.
+     * @param shows The list of TV shows to display.
+     */
+    public void setShows(List<AssetSentiment> shows) {
+        showAdapter.setAssetSentiments(shows);
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/home/HomeFragment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/home/HomeFragment.java
@@ -4,22 +4,38 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.model.AssetType;
+import com.google.moviestvsentiments.model.SentimentType;
+import com.google.moviestvsentiments.service.assetSentiment.AssetSentimentViewModel;
+import com.google.moviestvsentiments.usecase.component.AssetListScreen;
+import com.google.moviestvsentiments.usecase.signin.SigninActivity;
+import javax.inject.Inject;
+import dagger.hilt.android.AndroidEntryPoint;
 
 /**
  * A fragment that displays the list of assets that have not been reacted to.
  */
+@AndroidEntryPoint
 public class HomeFragment extends Fragment {
+
+    @Inject
+    AssetSentimentViewModel viewModel;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        View root = inflater.inflate(R.layout.fragment_home, container, false);
-        final TextView textView = root.findViewById(R.id.text_home);
-        textView.setText("This is the home fragment.");
+        View root = inflater.inflate(R.layout.asset_lists_screen, container, false);
+        AssetListScreen assetListScreen = AssetListScreen.create(root, container.getContext());
+
+        String accountName = getActivity().getIntent().getStringExtra(SigninActivity.EXTRA_ACCOUNT_NAME);
+        viewModel.getAssets(AssetType.MOVIE, accountName, SentimentType.UNSPECIFIED)
+            .observe(getViewLifecycleOwner(), movies -> assetListScreen.setMovies(movies));
+        viewModel.getAssets(AssetType.SHOW, accountName, SentimentType.UNSPECIFIED)
+            .observe(getViewLifecycleOwner(), shows -> assetListScreen.setShows(shows));
+
         return root;
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/navigation/SentimentsNavigationActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/navigation/SentimentsNavigationActivity.java
@@ -8,10 +8,12 @@ import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
+import dagger.hilt.android.AndroidEntryPoint;
 
 /**
  * An activity that manages switching between the Home, Liked and Disliked tabs.
  */
+@AndroidEntryPoint
 public class SentimentsNavigationActivity extends AppCompatActivity {
 
     @Override

--- a/MoviesTVSentiments/app/src/main/res/layouts/home/layout/fragment_home.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/home/layout/fragment_home.xml
@@ -7,16 +7,47 @@
     tools:context=".usecase.home.HomeFragment">
 
     <TextView
-        android:id="@+id/text_home"
-        android:layout_width="match_parent"
+        android:id="@+id/movies_label"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:textAlignment="center"
-        android:textSize="20sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginLeft="@dimen/bigPadding"
+        android:layout_marginTop="@dimen/bigPadding"
+        android:text="@string/movies_label"
+        android:textSize="@dimen/title_font_size"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/movies_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/bigPadding"
+        android:paddingLeft="@dimen/bigPadding"
+        android:clipToPadding="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/movies_label" />
+
+    <TextView
+        android:id="@+id/tvshows_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/bigPadding"
+        android:layout_marginTop="@dimen/bigPadding"
+        android:text="@string/tvshows_label"
+        android:textSize="@dimen/title_font_size"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/movies_list" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/tvshows_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/bigPadding"
+        android:paddingLeft="@dimen/bigPadding"
+        android:clipToPadding="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tvshows_label" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/MoviesTVSentiments/app/src/test-common/java/com/google/moviestvsentiments/util/AssetUtil.java
+++ b/MoviesTVSentiments/app/src/test-common/java/com/google/moviestvsentiments/util/AssetUtil.java
@@ -1,0 +1,32 @@
+package com.google.moviestvsentiments.util;
+
+import com.google.moviestvsentiments.model.Asset;
+import com.google.moviestvsentiments.model.AssetType;
+
+/**
+ * AssetUtil provides helper functions for working with Asset objects.
+ */
+public class AssetUtil {
+
+    /**
+     * Creates an asset of type MOVIE with the given id.
+     * @param assetId The id to create the asset with.
+     * @return A movie asset with the given id.
+     */
+    public static Asset createMovieAsset(String assetId) {
+        return Asset.builder().setId(assetId).setType(AssetType.MOVIE).setTitle("assetTitle")
+                .setPoster("posterURL").setBanner("bannerURL").setPlot("plotDescription")
+                .setRuntime("runtime").setYear("year").setTimestamp(1).build();
+    }
+
+    /**
+     * Creates an asset of type SHOW with the given id.
+     * @param assetId The id to create the asset with.
+     * @return A show asset with the given id.
+     */
+    public static Asset createShowAsset(String assetId) {
+        return Asset.builder().setId(assetId).setType(AssetType.SHOW).setTitle("assetTitle")
+                .setPoster("posterURL").setBanner("bannerURL").setYear("year")
+                .setPlot("plotDescription").setRuntime("runtime").setTimestamp(1).build();
+    }
+}

--- a/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentRepositoryTest.java
+++ b/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentRepositoryTest.java
@@ -12,6 +12,7 @@ import com.google.moviestvsentiments.model.AssetSentiment;
 import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
 import com.google.moviestvsentiments.service.MainThreadDatabaseExecutor;
+import com.google.moviestvsentiments.util.AssetUtil;
 import com.google.moviestvsentiments.util.LiveDataTestUtil;
 import org.junit.Before;
 import org.junit.Rule;
@@ -24,9 +25,7 @@ import java.util.List;
 @RunWith(JUnit4.class)
 public class AssetSentimentRepositoryTest {
 
-    private static final Asset ASSET = Asset.builder().setId("assetId").setType(AssetType.SHOW)
-        .setTitle("assetTitle").setPoster("posterURL").setBanner("bannerURL").setYear("year")
-        .setPlot("plotDescription").setRuntime("runtime").setTimestamp(1).build();
+    private static final Asset ASSET = AssetUtil.createShowAsset("assetId");
 
     @Rule
     public InstantTaskExecutorRule instantExecutorRule = new InstantTaskExecutorRule();

--- a/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentViewModelTest.java
+++ b/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentViewModelTest.java
@@ -11,6 +11,7 @@ import com.google.moviestvsentiments.model.Asset;
 import com.google.moviestvsentiments.model.AssetSentiment;
 import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
+import com.google.moviestvsentiments.util.AssetUtil;
 import com.google.moviestvsentiments.util.LiveDataTestUtil;
 import org.junit.Before;
 import org.junit.Rule;
@@ -23,9 +24,7 @@ import java.util.List;
 @RunWith(JUnit4.class)
 public class AssetSentimentViewModelTest {
 
-    private static final Asset ASSET = Asset.builder().setId("assetId").setType(AssetType.SHOW)
-            .setTitle("assetTitle").setPoster("posterURL").setBanner("bannerURL").setYear("year")
-            .setPlot("plotDescription").setRuntime("runtime").setTimestamp(1).build();
+    private static final Asset ASSET = AssetUtil.createShowAsset("assetId");
 
     @Rule
     public InstantTaskExecutorRule instantExecutorRule = new InstantTaskExecutorRule();


### PR DESCRIPTION
The HomeFragment now displays a list of movies and a list of TV shows that either have not been reacted to by the current account or have a reaction of type UNSPECIFIED. Glide is used to load images from the poster URL, as recommended here: https://developer.android.com/topic/performance/graphics/index.html. Also adds test classes and configuration. 