### PR TITLE
Improve continuous integration workflow

### DIFF
--- a/.github/workflows/test-workflow.yaml
+++ b/.github/workflows/test-workflow.yaml
@@ -23,7 +23,10 @@ jobs:
         with:
           working-directory: ./MoviesTVSentiments
           api-level: 29
-          script: ./gradlew connectedAndroidTest --info
+          script: |
+            adb logcat -c
+            adb logcat *:E &
+            ./gradlew connectedAndroidTest
 
       - name: Upload test report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test-workflow.yaml
+++ b/.github/workflows/test-workflow.yaml
@@ -25,3 +25,9 @@ jobs:
           api-level: 29
           script: ./gradlew connectedAndroidTest --info
 
+      - name: Upload test report
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-report
+          path: /Users/runner/work/play-movies-2020-intern/play-movies-2020-intern/MoviesTVSentiments/app/build/reports/androidTests/connected/ 


### PR DESCRIPTION
Changes the script that is run during the Espresso tests in order to get more meaningful output. Also, if the Espresso tests fail, the test report is saved as a test artifact. These changes should hopefully make debugging CI errors easier.