### PR TITLE
Send intent from AssetListFragment to DetailsActivity on asset click

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -60,9 +60,10 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
-    // Auto value
+    // Auto value and parcelable
     api "com.google.auto.value:auto-value-annotations:${autoValueVersion}"
     annotationProcessor "com.google.auto.value:auto-value:${autoValueVersion}"
+    annotationProcessor 'com.ryanharter.auto.value:auto-value-parcel:0.2.7'
 
     // Hilt
     implementation "com.google.dagger:hilt-android:$rootProject.hiltVersion"

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/Asset.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/Asset.java
@@ -1,5 +1,6 @@
 package com.google.moviestvsentiments.model;
 
+import android.os.Parcelable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.room.ColumnInfo;
@@ -11,7 +12,7 @@ import com.google.auto.value.AutoValue;
  */
 @AutoValue
 @Entity(tableName = "assets_table", primaryKeys = {"asset_id", "asset_type"})
-public abstract class Asset {
+public abstract class Asset implements Parcelable {
 
     @AutoValue.CopyAnnotations
     @NonNull

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/AssetSentiment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/AssetSentiment.java
@@ -1,14 +1,14 @@
 package com.google.moviestvsentiments.model;
 
+import android.os.Parcelable;
 import androidx.room.Embedded;
-
 import com.google.auto.value.AutoValue;
 
 /**
  * A container that combines an asset with a sentiment type.
  */
 @AutoValue
-public abstract class AssetSentiment {
+public abstract class AssetSentiment implements Parcelable {
     @AutoValue.CopyAnnotations
     @Embedded
     public abstract Asset asset();

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListAdapter.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListAdapter.java
@@ -19,15 +19,31 @@ import java.util.List;
 public class AssetListAdapter extends RecyclerView.Adapter<AssetListAdapter.AssetViewHolder> {
 
     /**
+     * Provides callbacks to be invoked when an asset is clicked.
+     */
+    interface AssetClickListener {
+        /**
+         * Handles an asset in the asset list being clicked.
+         * @param assetSentiment An AssetSentiment object containing the clicked asset and the
+         *                       current user's sentiment toward that asset.
+         */
+        void onAssetClick(AssetSentiment assetSentiment);
+    }
+
+    /**
      * A container that holds metadata about an item view in the asset list.
      */
-    static class AssetViewHolder extends RecyclerView.ViewHolder {
+    static class AssetViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
         private final ImageView imageView;
+        private final AssetClickListener assetClickListener;
+        private AssetSentiment assetSentiment;
 
-        private AssetViewHolder(@NonNull View itemView) {
+        private AssetViewHolder(@NonNull View itemView, AssetClickListener assetClickListener) {
             super(itemView);
+            itemView.setOnClickListener(this);
             imageView = itemView.findViewById(R.id.asset_card_image);
+            this.assetClickListener = assetClickListener;
         }
 
         /**
@@ -37,21 +53,31 @@ public class AssetListAdapter extends RecyclerView.Adapter<AssetListAdapter.Asse
          *                       AssetViewHolder.
          */
         private void bind(AssetSentiment assetSentiment) {
+            this.assetSentiment = assetSentiment;
             Glide.with(imageView).load(assetSentiment.asset().poster()).into(imageView);
+        }
+
+        @Override
+        public void onClick(View view) {
+            assetClickListener.onAssetClick(assetSentiment);
         }
     }
 
+    private final AssetClickListener assetClickListener;
     private List<AssetSentiment> assetSentiments;
 
-    private AssetListAdapter() {
+    private AssetListAdapter(AssetClickListener assetClickListener) {
+        this.assetClickListener = assetClickListener;
         assetSentiments = new ArrayList<>();
     }
 
     /**
      * Returns a new AssetListAdapter.
+     * @param assetClickListener The listener to invoke when an asset is clicked.
+     * @return A new AssetListAdapter.
      */
-    public static AssetListAdapter create() {
-        return new AssetListAdapter();
+    public static AssetListAdapter create(AssetClickListener assetClickListener) {
+        return new AssetListAdapter(assetClickListener);
     }
 
     /**
@@ -68,7 +94,7 @@ public class AssetListAdapter extends RecyclerView.Adapter<AssetListAdapter.Asse
     public AssetViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.asset_list_item,
                 parent, false);
-        return new AssetViewHolder(itemView);
+        return new AssetViewHolder(itemView, assetClickListener);
     }
 
     @Override

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragment.java
@@ -1,5 +1,6 @@
 package com.google.moviestvsentiments.usecase.assetList;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -7,9 +8,11 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.model.AssetSentiment;
 import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
 import com.google.moviestvsentiments.service.assetSentiment.AssetSentimentViewModel;
+import com.google.moviestvsentiments.usecase.details.DetailsActivity;
 import com.google.moviestvsentiments.usecase.signin.SigninActivity;
 import javax.inject.Inject;
 import dagger.hilt.android.AndroidEntryPoint;
@@ -19,7 +22,9 @@ import dagger.hilt.android.AndroidEntryPoint;
  * arguments.
  */
 @AndroidEntryPoint
-public class AssetListFragment extends Fragment {
+public class AssetListFragment extends Fragment implements AssetListAdapter.AssetClickListener {
+
+    public static final String EXTRA_ASSET_SENTIMENT = "com.google.moviestvsentiments.ASSET_SENTIMENT";
 
     @Inject
     AssetSentimentViewModel viewModel;
@@ -28,7 +33,8 @@ public class AssetListFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View root = inflater.inflate(R.layout.asset_lists_screen, container, false);
-        AssetListScreen assetListScreen = AssetListScreen.create(root, container.getContext());
+        AssetListScreen assetListScreen = AssetListScreen.create(this, root,
+                container.getContext());
 
         String accountName = getActivity().getIntent().getStringExtra(SigninActivity.EXTRA_ACCOUNT_NAME);
         SentimentType sentimentType = AssetListFragmentArgs.fromBundle(getArguments())
@@ -39,5 +45,16 @@ public class AssetListFragment extends Fragment {
                 .observe(getViewLifecycleOwner(), shows -> assetListScreen.setShows(shows));
 
         return root;
+    }
+
+    /**
+     * Sends an intent containing the given AssetSentiment object to the DetailsActivity.
+     * @param assetSentiment The AssetSentiment object to pass to the DetailsActivity.
+     */
+    @Override
+    public void onAssetClick(AssetSentiment assetSentiment) {
+        Intent intent = new Intent(getContext(), DetailsActivity.class);
+        intent.putExtra(EXTRA_ASSET_SENTIMENT, assetSentiment);
+        startActivity(intent);
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListScreen.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListScreen.java
@@ -16,20 +16,22 @@ public class AssetListScreen {
     private AssetListAdapter movieAdapter;
     private AssetListAdapter showAdapter;
 
-    private AssetListScreen() {
-        movieAdapter = AssetListAdapter.create();
-        showAdapter = AssetListAdapter.create();
+    private AssetListScreen(AssetListAdapter.AssetClickListener assetClickListener) {
+        movieAdapter = AssetListAdapter.create(assetClickListener);
+        showAdapter = AssetListAdapter.create(assetClickListener);
     }
 
     /**
      * Creates a new AssetListScreen.
+     * @param assetClickListener The listener to invoke when an asset is clicked.
      * @param root The root view where the AssetListScreen is displayed. It must contain recycler
      *             views with the movies_list and the tvshows_list ids.
      * @param context The context where the AssetListScreen is displayed.
      * @return A new AssetListScreen.
      */
-    public static AssetListScreen create(View root, Context context) {
-        AssetListScreen assetListScreen = new AssetListScreen();
+    public static AssetListScreen create(AssetListAdapter.AssetClickListener assetClickListener,
+                                         View root, Context context) {
+        AssetListScreen assetListScreen = new AssetListScreen(assetClickListener);
         assetListScreen.setupLists(root, context);
         return assetListScreen;
     }


### PR DESCRIPTION
Adds functionality to the AssetListAdapter and AssetListFragment so that when an item in the asset list is clicked, that asset is sent in an intent to the DetailsActivity. To support this, Asset and AssetSentiment now implement the Parcelable framework.