### PR TITLE
Fix test method in SigninActivityTest

### DIFF
--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
@@ -34,10 +34,8 @@ public class SigninActivityTest {
 
     @Rule
     public RuleChain rule = RuleChain.outerRule(new HiltAndroidRule(this))
-            .around(new IntentsTestRule<>(SigninActivity.class));
-
-    @Rule
-    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+            .around(new IntentsTestRule<>(SigninActivity.class))
+            .around(new InstantTaskExecutorRule());
 
     @Test
     public void signinActivity_displaysOnlyAddAccount() {

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/AccountListAdapter.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/AccountListAdapter.java
@@ -69,6 +69,7 @@ class AccountListAdapter extends RecyclerView.Adapter<AccountListAdapter.Account
 
     private AccountListAdapter(AccountClickListener accountClickListener) {
         this.accountClickListener = accountClickListener;
+        accounts = new ArrayList<>();
     }
 
     /**
@@ -107,9 +108,6 @@ class AccountListAdapter extends RecyclerView.Adapter<AccountListAdapter.Account
 
     @Override
     public int getItemCount() {
-        if (accounts == null) {
-            return 0;
-        }
         // Add one extra item for the Add Account item
         return accounts.size() + 1;
     }


### PR DESCRIPTION
There are currently two test methods in SigninActivityTest that occasionally fail when run in the CI workflow:
- signinActivity_clickAddAccount_sendsIntentToAddAccountActivity
- signinActivity_addAccountResultCanceled_displaysOnlyAddAccount

This pull request should fix the first test by ensuring that the `Add Account` item is always present in the account list, regardless of whether the live data object has returned a value or not.