### PR TITLE
[DRAFT] Attempts to display AssetSentiment info in DetailsActivity

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -60,9 +60,10 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
-    // Auto value
+    // Auto value and parcelable
     api "com.google.auto.value:auto-value-annotations:${autoValueVersion}"
     annotationProcessor "com.google.auto.value:auto-value:${autoValueVersion}"
+    annotationProcessor 'com.ryanharter.auto.value:auto-value-parcel:0.2.7'
 
     // Hilt
     implementation "com.google.dagger:hilt-android:$rootProject.hiltVersion"

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/assertions/ImageViewDrawableMatcher.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/assertions/ImageViewDrawableMatcher.java
@@ -1,0 +1,105 @@
+package com.google.moviestvsentiments.assertions;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.ColorMatrix;
+import android.graphics.ColorMatrixColorFilter;
+import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
+import android.util.Log;
+import android.view.View;
+import android.widget.ImageView;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * A TypeSafeMatcher that verifies that an ImageView is displaying a drawable with a given resource
+ * id.
+ */
+public class ImageViewDrawableMatcher extends TypeSafeMatcher<View> {
+
+    private static final String TAG = "ImageViewDrawableMatche";
+
+    private final int drawableId;
+
+    private ImageViewDrawableMatcher(int drawableId) {
+        this.drawableId = drawableId;
+    }
+
+    /**
+     * Returns a new ImageViewDrawableAssertion that checks the image view for the given drawable.
+     * @param drawableId The id of the drawable to check for.
+     * @return A new ImageViewDrawableAssertion that checks the image view for the given drawable.
+     */
+    public static ImageViewDrawableMatcher withDrawable(int drawableId) {
+        return new ImageViewDrawableMatcher(drawableId);
+    }
+
+    /**
+     * Returns the Bitmap for the given Drawable.
+     * @param drawable The Drawable to get the Bitmap for.
+     * @return The Bitmap for the given Drawable.
+     */
+    private Bitmap getBitmap(Drawable drawable) {
+        Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(),
+                drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        Log.d(TAG, "getBitmap: Bounds: " + drawable.getBounds());
+        drawable.draw(canvas);
+
+        Bitmap bmpGrayscale = Bitmap.createBitmap(drawable.getIntrinsicWidth(),
+                drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+        Canvas c = new Canvas(bmpGrayscale);
+        Paint paint = new Paint();
+        ColorMatrix cm = new ColorMatrix();
+        cm.setSaturation(0);
+        ColorMatrixColorFilter f = new ColorMatrixColorFilter(cm);
+        paint.setColorFilter(f);
+        c.drawBitmap(bitmap, 0, 0, paint);
+        return bmpGrayscale;
+//        return bitmap;
+    }
+
+    @Override
+    protected boolean matchesSafely(View item) {
+        if (!(item instanceof ImageView)) {
+            return false;
+        }
+
+        ImageView imageView = (ImageView)item;
+        Bitmap actualBitmap = getBitmap(imageView.getDrawable());
+        Log.d(TAG, "matchesSafely: Image drawable: " + imageView.getDrawable());
+        Drawable expectedDrawable = imageView.getContext().getDrawable(drawableId);
+        Log.d(TAG, "matchesSafely: Expected drawable " + expectedDrawable);
+        Bitmap expectedBitmap = getBitmap(expectedDrawable);
+
+        Log.d(TAG, "matchesSafely: Resource name: " + imageView.getContext().getResources().getResourceEntryName(drawableId));
+        checkBitmaps(actualBitmap, expectedBitmap);
+        return expectedBitmap.sameAs(actualBitmap);
+    }
+
+    private void checkBitmaps(Bitmap lhs, Bitmap rhs) {
+        if (lhs.getHeight() != rhs.getHeight()) {
+            Log.d(TAG, "checkBitmaps: heights are inequal");
+        }
+        if (lhs.getWidth() != rhs.getWidth()) {
+            Log.d(TAG, "checkBitmaps: widths are inequal");
+        }
+
+        for (int i = 0; i < lhs.getWidth(); i++) {
+            for (int j = 0; j < lhs.getHeight(); j++) {
+                if (lhs.getPixel(i, j) != rhs.getPixel(i, j)) {
+                    Log.d(TAG, "checkBitmaps: Pixel (" + i + ", " + j + ") is inequal");
+                    Log.d(TAG, "checkBitmaps: LHS: " + lhs.getPixel(i, j) + ", RHS: " + rhs.getPixel(i, j));
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("ImageView with drawable from resource id: " + drawableId);
+    }
+}

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/details/DetailsActivityTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/details/DetailsActivityTest.java
@@ -1,0 +1,87 @@
+package com.google.moviestvsentiments.usecase.details;
+
+import android.content.Intent;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.test.rule.ActivityTestRule;
+
+import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.model.Asset;
+import com.google.moviestvsentiments.model.AssetSentiment;
+import com.google.moviestvsentiments.model.SentimentType;
+import com.google.moviestvsentiments.usecase.assetList.AssetListFragment;
+import com.google.moviestvsentiments.util.AssetUtil;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static com.google.moviestvsentiments.assertions.ImageViewDrawableMatcher.withDrawable;
+
+@RunWith(JUnitParamsRunner.class)
+public class DetailsActivityTest {
+
+    @Rule
+    public ActivityTestRule<DetailsActivity> activityTestRule =
+            new ActivityTestRule<>(DetailsActivity.class, false, false);
+
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    private Object[] displaysAssetInfoValues() {
+        return new Object[] {
+            new Object[] {SentimentType.UNSPECIFIED},
+            new Object[] {SentimentType.THUMBS_UP},
+            new Object[] {SentimentType.THUMBS_DOWN}
+        };
+    }
+
+    @Test
+    @Parameters(method = "displaysAssetInfoValues")
+    public void detailsActivity_displaysAssetInfo(SentimentType sentimentType) {
+        Asset asset = AssetUtil.defaultMovieBuilder("assetId").setTitle("Asset Title")
+                .setPlot("Description of the plot").setImdbRating("4.7").build();
+        AssetSentiment assetSentiment = AssetSentiment.create(asset, sentimentType);
+        Intent intent = new Intent();
+        intent.putExtra(AssetListFragment.EXTRA_ASSET_SENTIMENT, assetSentiment);
+
+        activityTestRule.launchActivity(intent);
+
+        onView(withId(R.id.asset_title)).check(matches(withText("Asset Title")));
+        onView(withId(R.id.rating)).check(matches(withText("4.7")));
+        onView(withId(R.id.description)).check(matches(withText("Description of the plot")));
+    }
+
+    private Object[] displaysSentimentValues() {
+        return new Object[] {
+            new Object[] {SentimentType.UNSPECIFIED, R.drawable.ic_outline_thumb_up_24,
+                    R.drawable.ic_outline_thumb_down_24},
+            new Object[] {SentimentType.THUMBS_UP, R.drawable.ic_baseline_thumb_up_24,
+                    R.drawable.ic_outline_thumb_down_24},
+            new Object[] {SentimentType.THUMBS_DOWN, R.drawable.ic_outline_thumb_up_24,
+                    R.drawable.ic_baseline_thumb_down_24}
+        };
+    }
+
+    @Test
+    @Parameters(method = "displaysSentimentValues")
+    public void detailsActivity_displaysSentiment(SentimentType sentimentType, int thumbsUpIcon,
+                                                  int thumbsDownIcon) {
+        AssetSentiment assetSentiment = AssetSentiment.create(
+                AssetUtil.createMovieAsset("assetId"), sentimentType);
+        Intent intent = new Intent();
+        intent.putExtra(AssetListFragment.EXTRA_ASSET_SENTIMENT, assetSentiment);
+
+        activityTestRule.launchActivity(intent);
+
+        onView(withId(R.id.thumbs_up)).check(matches(withDrawable(thumbsUpIcon)));
+        onView(withId(R.id.thumbs_down)).check(matches(withDrawable(thumbsDownIcon)));
+    }
+}

--- a/MoviesTVSentiments/app/src/main/AndroidManifest.xml
+++ b/MoviesTVSentiments/app/src/main/AndroidManifest.xml
@@ -12,14 +12,16 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".usecase.details.DetailsActivity" />
+        <activity android:name=".usecase.details.DetailsActivity" >
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+        </activity>
         <activity android:name=".usecase.navigation.SentimentsNavigationActivity" />
         <activity android:name=".usecase.addAccount.AddAccountActivity" />
         <activity android:name=".usecase.signin.SigninActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+
         </activity>
     </application>
 

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/Asset.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/Asset.java
@@ -1,5 +1,6 @@
 package com.google.moviestvsentiments.model;
 
+import android.os.Parcelable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.room.ColumnInfo;
@@ -11,7 +12,7 @@ import com.google.auto.value.AutoValue;
  */
 @AutoValue
 @Entity(tableName = "assets_table", primaryKeys = {"asset_id", "asset_type"})
-public abstract class Asset {
+public abstract class Asset implements Parcelable {
 
     @AutoValue.CopyAnnotations
     @NonNull

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/AssetSentiment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/AssetSentiment.java
@@ -1,14 +1,14 @@
 package com.google.moviestvsentiments.model;
 
+import android.os.Parcelable;
 import androidx.room.Embedded;
-
 import com.google.auto.value.AutoValue;
 
 /**
  * A container that combines an asset with a sentiment type.
  */
 @AutoValue
-public abstract class AssetSentiment {
+public abstract class AssetSentiment implements Parcelable {
     @AutoValue.CopyAnnotations
     @Embedded
     public abstract Asset asset();

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListAdapter.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListAdapter.java
@@ -19,15 +19,31 @@ import java.util.List;
 public class AssetListAdapter extends RecyclerView.Adapter<AssetListAdapter.AssetViewHolder> {
 
     /**
+     * Provides callbacks to be invoked when an asset is clicked.
+     */
+    interface AssetClickListener {
+        /**
+         * Handles an asset in the asset list being clicked.
+         * @param assetSentiment An AssetSentiment object containing the clicked asset and the
+         *                       current user's sentiment toward that asset.
+         */
+        void onAssetClick(AssetSentiment assetSentiment);
+    }
+
+    /**
      * A container that holds metadata about an item view in the asset list.
      */
-    static class AssetViewHolder extends RecyclerView.ViewHolder {
+    static class AssetViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
         private final ImageView imageView;
+        private final AssetClickListener assetClickListener;
+        private AssetSentiment assetSentiment;
 
-        private AssetViewHolder(@NonNull View itemView) {
+        private AssetViewHolder(@NonNull View itemView, AssetClickListener assetClickListener) {
             super(itemView);
+            itemView.setOnClickListener(this);
             imageView = itemView.findViewById(R.id.asset_card_image);
+            this.assetClickListener = assetClickListener;
         }
 
         /**
@@ -37,21 +53,31 @@ public class AssetListAdapter extends RecyclerView.Adapter<AssetListAdapter.Asse
          *                       AssetViewHolder.
          */
         private void bind(AssetSentiment assetSentiment) {
+            this.assetSentiment = assetSentiment;
             Glide.with(imageView).load(assetSentiment.asset().poster()).into(imageView);
+        }
+
+        @Override
+        public void onClick(View view) {
+            assetClickListener.onAssetClick(assetSentiment);
         }
     }
 
+    private final AssetClickListener assetClickListener;
     private List<AssetSentiment> assetSentiments;
 
-    private AssetListAdapter() {
+    private AssetListAdapter(AssetClickListener assetClickListener) {
+        this.assetClickListener = assetClickListener;
         assetSentiments = new ArrayList<>();
     }
 
     /**
      * Returns a new AssetListAdapter.
+     * @param assetClickListener The listener to invoke when an asset is clicked.
+     * @return A new AssetListAdapter.
      */
-    public static AssetListAdapter create() {
-        return new AssetListAdapter();
+    public static AssetListAdapter create(AssetClickListener assetClickListener) {
+        return new AssetListAdapter(assetClickListener);
     }
 
     /**
@@ -68,7 +94,7 @@ public class AssetListAdapter extends RecyclerView.Adapter<AssetListAdapter.Asse
     public AssetViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         View itemView = LayoutInflater.from(parent.getContext()).inflate(R.layout.asset_list_item,
                 parent, false);
-        return new AssetViewHolder(itemView);
+        return new AssetViewHolder(itemView, assetClickListener);
     }
 
     @Override

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragment.java
@@ -1,5 +1,6 @@
 package com.google.moviestvsentiments.usecase.assetList;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -7,9 +8,11 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.model.AssetSentiment;
 import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
 import com.google.moviestvsentiments.service.assetSentiment.AssetSentimentViewModel;
+import com.google.moviestvsentiments.usecase.details.DetailsActivity;
 import com.google.moviestvsentiments.usecase.signin.SigninActivity;
 import javax.inject.Inject;
 import dagger.hilt.android.AndroidEntryPoint;
@@ -19,7 +22,9 @@ import dagger.hilt.android.AndroidEntryPoint;
  * arguments.
  */
 @AndroidEntryPoint
-public class AssetListFragment extends Fragment {
+public class AssetListFragment extends Fragment implements AssetListAdapter.AssetClickListener {
+
+    public static final String EXTRA_ASSET_SENTIMENT = "com.google.moviestvsentiments.ASSET_SENTIMENT";
 
     @Inject
     AssetSentimentViewModel viewModel;
@@ -28,7 +33,8 @@ public class AssetListFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View root = inflater.inflate(R.layout.asset_lists_screen, container, false);
-        AssetListScreen assetListScreen = AssetListScreen.create(root, container.getContext());
+        AssetListScreen assetListScreen = AssetListScreen.create(this, root,
+                container.getContext());
 
         String accountName = getActivity().getIntent().getStringExtra(SigninActivity.EXTRA_ACCOUNT_NAME);
         SentimentType sentimentType = AssetListFragmentArgs.fromBundle(getArguments())
@@ -39,5 +45,16 @@ public class AssetListFragment extends Fragment {
                 .observe(getViewLifecycleOwner(), shows -> assetListScreen.setShows(shows));
 
         return root;
+    }
+
+    /**
+     * Sends an intent containing the given AssetSentiment object to the DetailsActivity.
+     * @param assetSentiment The AssetSentiment object to pass to the DetailsActivity.
+     */
+    @Override
+    public void onAssetClick(AssetSentiment assetSentiment) {
+        Intent intent = new Intent(getContext(), DetailsActivity.class);
+        intent.putExtra(EXTRA_ASSET_SENTIMENT, assetSentiment);
+        startActivity(intent);
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListScreen.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListScreen.java
@@ -16,20 +16,22 @@ public class AssetListScreen {
     private AssetListAdapter movieAdapter;
     private AssetListAdapter showAdapter;
 
-    private AssetListScreen() {
-        movieAdapter = AssetListAdapter.create();
-        showAdapter = AssetListAdapter.create();
+    private AssetListScreen(AssetListAdapter.AssetClickListener assetClickListener) {
+        movieAdapter = AssetListAdapter.create(assetClickListener);
+        showAdapter = AssetListAdapter.create(assetClickListener);
     }
 
     /**
      * Creates a new AssetListScreen.
+     * @param assetClickListener The listener to invoke when an asset is clicked.
      * @param root The root view where the AssetListScreen is displayed. It must contain recycler
      *             views with the movies_list and the tvshows_list ids.
      * @param context The context where the AssetListScreen is displayed.
      * @return A new AssetListScreen.
      */
-    public static AssetListScreen create(View root, Context context) {
-        AssetListScreen assetListScreen = new AssetListScreen();
+    public static AssetListScreen create(AssetListAdapter.AssetClickListener assetClickListener,
+                                         View root, Context context) {
+        AssetListScreen assetListScreen = new AssetListScreen(assetClickListener);
         assetListScreen.setupLists(root, context);
         return assetListScreen;
     }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/details/DetailsActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/details/DetailsActivity.java
@@ -1,14 +1,119 @@
 package com.google.moviestvsentiments.usecase.details;
 
 import androidx.appcompat.app.AppCompatActivity;
-import android.os.Bundle;
-import com.google.moviestvsentiments.R;
 
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.ColorMatrix;
+import android.graphics.ColorMatrixColorFilter;
+import android.graphics.Paint;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+import com.bumptech.glide.Glide;
+import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.model.Asset;
+import com.google.moviestvsentiments.model.AssetSentiment;
+import com.google.moviestvsentiments.model.AssetType;
+import com.google.moviestvsentiments.model.SentimentType;
+import com.google.moviestvsentiments.usecase.assetList.AssetListFragment;
+
+/**
+ * An Activity that displays the details of an AssetSentiment object. The AssetSentiment must
+ * be passed in the intent that launched the DetailsActivity.
+ */
 public class DetailsActivity extends AppCompatActivity {
+
+    private static final String TAG = "DetailsActivity";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_details);
+
+//        Asset asset = Asset.builder().setId("assetId").setType(AssetType.MOVIE).setTitle("assetTitle")
+//                .setPoster("posterURL").setBanner("bannerURL").setPlot("plotDescription")
+//                .setRuntime("runtime").setYear("year").setTimestamp(1).build();
+//        AssetSentiment assetSentiment = AssetSentiment.create(asset, SentimentType.THUMBS_DOWN);
+        AssetSentiment assetSentiment = getIntent()
+                .getParcelableExtra(AssetListFragment.EXTRA_ASSET_SENTIMENT);
+        bind(assetSentiment);
+    }
+
+    /**
+     * Sets the various views in the DetailsActivity to display the information in the given
+     * AssetSentiment.
+     * @param assetSentiment The AssetSentiment to display.
+     */
+    private void bind(AssetSentiment assetSentiment) {
+//        ImageView banner = findViewById(R.id.banner_image);
+//        Glide.with(this).load(assetSentiment.asset().banner()).into(banner);
+//
+//        ImageView poster = findViewById(R.id.poster_image);
+//        Glide.with(this).load(assetSentiment.asset().poster()).into(poster);
+
+        TextView title = findViewById(R.id.asset_title);
+        title.setText(assetSentiment.asset().title());
+
+        TextView rating = findViewById(R.id.rating);
+        rating.setText(assetSentiment.asset().imdbRating());
+
+        TextView description = findViewById(R.id.description);
+        description.setText(assetSentiment.asset().plot());
+
+        switch (assetSentiment.sentimentType()) {
+            case THUMBS_UP:
+//                Drawable filledThumbUp = getDrawable(R.drawable.ic_baseline_thumb_up_24);
+                ImageView thumbsUp = findViewById(R.id.thumbs_up);
+//                thumbsUp.setImageDrawable(filledThumbUp);
+                thumbsUp.setImageResource(R.drawable.ic_baseline_thumb_up_24);
+                if (matchesSafely(thumbsUp)) {
+                    Log.d(TAG, "bind: matches safely returned true");
+                } else {
+                    Log.d(TAG, "bind: matches safely returned false");
+                }
+                break;
+            case THUMBS_DOWN:
+                Drawable filledThumbDown = getDrawable(R.drawable.ic_baseline_thumb_down_24);
+                ImageView thumbsDown = findViewById(R.id.thumbs_down);
+                thumbsDown.setImageDrawable(filledThumbDown);
+                break;
+            default:
+        }
+    }
+
+    /**
+     * Returns the Bitmap for the given Drawable.
+     * @param drawable The Drawable to get the Bitmap for.
+     * @return The Bitmap for the given Drawable.
+     */
+    private Bitmap getBitmap(Drawable drawable) {
+        Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(),
+                drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        Log.d(TAG, "getBitmap: Bounds: " + drawable.getBounds());
+        drawable.draw(canvas);
+        return bitmap;
+    }
+
+    protected boolean matchesSafely(View item) {
+        if (!(item instanceof ImageView)) {
+            return false;
+        }
+
+        ImageView imageView = (ImageView)item;
+        Bitmap actualBitmap = getBitmap(imageView.getDrawable());
+        Log.d(TAG, "matchesSafely: Image drawable: " + imageView.getDrawable());
+        Drawable expectedDrawable = imageView.getContext().getDrawable(R.drawable.ic_outline_thumb_up_24);
+        Log.d(TAG, "matchesSafely: Expected drawable " + expectedDrawable);
+        Bitmap expectedBitmap = getBitmap(expectedDrawable);
+
+        Log.d(TAG, "matchesSafely: Resource name: " + imageView.getContext().getResources().getResourceEntryName(R.drawable.ic_outline_thumb_up_24));
+//        checkBitmaps(actualBitmap, expectedBitmap);
+        return expectedBitmap.sameAs(actualBitmap);
     }
 }

--- a/MoviesTVSentiments/app/src/main/res/drawable/ic_outline_thumb_down_24.xml
+++ b/MoviesTVSentiments/app/src/main/res/drawable/ic_outline_thumb_down_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15,3L6,3c-0.83,0 -1.54,0.5 -1.84,1.22l-3.02,7.05c-0.09,0.23 -0.14,0.47 -0.14,0.73v2c0,1.1 0.9,2 2,2h6.31l-0.95,4.57 -0.03,0.32c0,0.41 0.17,0.79 0.44,1.06L9.83,23l6.59,-6.59c0.36,-0.36 0.58,-0.86 0.58,-1.41L17,5c0,-1.1 -0.9,-2 -2,-2zM15,15l-4.34,4.34L12,14L3,14v-2l3,-7h9v10zM19,3h4v12h-4z"/>
+</vector>

--- a/MoviesTVSentiments/app/src/main/res/drawable/ic_outline_thumb_up_24.xml
+++ b/MoviesTVSentiments/app/src/main/res/drawable/ic_outline_thumb_up_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M9,21h9c0.83,0 1.54,-0.5 1.84,-1.22l3.02,-7.05c0.09,-0.23 0.14,-0.47 0.14,-0.73v-2c0,-1.1 -0.9,-2 -2,-2h-6.31l0.95,-4.57 0.03,-0.32c0,-0.41 -0.17,-0.79 -0.44,-1.06L14.17,1 7.58,7.59C7.22,7.95 7,8.45 7,9v10c0,1.1 0.9,2 2,2zM9,9l4.34,-4.34L12,10h9v2l-3,7H9V9zM1,9h4v12H1z"/>
+</vector>

--- a/MoviesTVSentiments/app/src/main/res/layouts/details/layout/activity_details.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/details/layout/activity_details.xml
@@ -17,7 +17,6 @@
         android:id="@+id/banner_image"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:background="#AE2020"
         android:scaleType="centerCrop"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -39,7 +38,6 @@
         android:layout_height="200dp"
         android:layout_marginStart="32dp"
         android:layout_marginLeft="32dp"
-        android:background="#6E6565"
         android:scaleType="centerCrop"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/poster_margin_space" />
@@ -102,7 +100,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:src="@drawable/ic_baseline_thumb_up_24"
+        android:src="@drawable/ic_outline_thumb_up_24"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/top_line"
         app:layout_constraintEnd_toStartOf="@+id/center_guideline"/>
@@ -112,7 +110,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:src="@drawable/ic_baseline_thumb_down_24"
+        android:src="@drawable/ic_outline_thumb_down_24"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/center_guideline"
         app:layout_constraintTop_toBottomOf="@+id/top_line" />

--- a/MoviesTVSentiments/app/src/test-common/java/com/google/moviestvsentiments/util/AssetUtil.java
+++ b/MoviesTVSentiments/app/src/test-common/java/com/google/moviestvsentiments/util/AssetUtil.java
@@ -27,9 +27,7 @@ public class AssetUtil {
      * @return A movie asset with the given id.
      */
     public static Asset createMovieAsset(String assetId) {
-        return Asset.builder().setId(assetId).setType(AssetType.MOVIE).setTitle("assetTitle")
-                .setPoster("posterURL").setBanner("bannerURL").setPlot("plotDescription")
-                .setRuntime("runtime").setYear("year").setTimestamp(1).build();
+        return defaultMovieBuilder(assetId).build();
     }
 
     /**
@@ -41,5 +39,16 @@ public class AssetUtil {
         return Asset.builder().setId(assetId).setType(AssetType.SHOW).setTitle("assetTitle")
                 .setPoster("posterURL").setBanner("bannerURL").setYear("year")
                 .setPlot("plotDescription").setRuntime("runtime").setTimestamp(1).build();
+    }
+
+    /**
+     * Returns the default Asset Builder object for a movie asset with the given asset id.
+     * @param assetId The id of the asset to create.
+     * @return The default Asset Builder object for a movie asset with the given asset id.
+     */
+    public static Asset.Builder defaultMovieBuilder(String assetId) {
+        return Asset.builder().setId(assetId).setType(AssetType.MOVIE).setTitle("assetTitle")
+                .setPoster("posterURL").setBanner("bannerURL").setPlot("plotDescription")
+                .setRuntime("runtime").setYear("year").setTimestamp(1);
     }
 }


### PR DESCRIPTION
The bitmap check happens in ImageViewDrawableMatcher. The pushed version converts the bitmaps to grayscale before comparing, but I have also tried without doing that.