### PR TITLE
Display AssetSentiment data in DetailsActivity

### DIFF
--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/details/DetailsActivityTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/details/DetailsActivityTest.java
@@ -43,17 +43,20 @@ public class DetailsActivityTest {
     @Test
     @Parameters(method = "displaysAssetInfoValues")
     public void detailsActivity_displaysAssetInfo(SentimentType sentimentType) {
-        Asset asset = AssetUtil.defaultMovieBuilder("assetId").setTitle("Asset Title")
-                .setPlot("Description of the plot").setImdbRating("4.7").build();
+        final String title = "Asset Title";
+        final String plot = "Description of the plot";
+        final String imdbRating = "4.7";
+        Asset asset = AssetUtil.defaultMovieBuilder("assetId").setTitle(title).setPlot(plot)
+                .setImdbRating(imdbRating).build();
         AssetSentiment assetSentiment = AssetSentiment.create(asset, sentimentType);
         Intent intent = new Intent();
         intent.putExtra(AssetListFragment.EXTRA_ASSET_SENTIMENT, assetSentiment);
 
         activityTestRule.launchActivity(intent);
 
-        onView(withId(R.id.asset_title)).check(matches(withText("Asset Title")));
-        onView(withId(R.id.rating)).check(matches(withText("4.7")));
-        onView(withId(R.id.description)).check(matches(withText("Description of the plot")));
+        onView(withId(R.id.asset_title)).check(matches(withText(title)));
+        onView(withId(R.id.description)).check(matches(withText(plot)));
+        onView(withId(R.id.rating)).check(matches(withText(imdbRating)));
     }
 
     private Object[] displaysSentimentValues() {

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/details/DetailsActivityTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/details/DetailsActivityTest.java
@@ -1,0 +1,81 @@
+package com.google.moviestvsentiments.usecase.details;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.equalTo;
+
+import android.content.Intent;
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.test.rule.ActivityTestRule;
+import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.model.Asset;
+import com.google.moviestvsentiments.model.AssetSentiment;
+import com.google.moviestvsentiments.model.SentimentType;
+import com.google.moviestvsentiments.usecase.assetList.AssetListFragment;
+import com.google.moviestvsentiments.util.AssetUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@RunWith(JUnitParamsRunner.class)
+public class DetailsActivityTest {
+
+    @Rule
+    public ActivityTestRule<DetailsActivity> activityTestRule =
+            new ActivityTestRule<>(DetailsActivity.class, false, false);
+
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    private Object[] displaysAssetInfoValues() {
+        return new Object[] {
+            new Object[] {SentimentType.UNSPECIFIED},
+            new Object[] {SentimentType.THUMBS_UP},
+            new Object[] {SentimentType.THUMBS_DOWN}
+        };
+    }
+
+    @Test
+    @Parameters(method = "displaysAssetInfoValues")
+    public void detailsActivity_displaysAssetInfo(SentimentType sentimentType) {
+        Asset asset = AssetUtil.defaultMovieBuilder("assetId").setTitle("Asset Title")
+                .setPlot("Description of the plot").setImdbRating("4.7").build();
+        AssetSentiment assetSentiment = AssetSentiment.create(asset, sentimentType);
+        Intent intent = new Intent();
+        intent.putExtra(AssetListFragment.EXTRA_ASSET_SENTIMENT, assetSentiment);
+
+        activityTestRule.launchActivity(intent);
+
+        onView(withId(R.id.asset_title)).check(matches(withText("Asset Title")));
+        onView(withId(R.id.rating)).check(matches(withText("4.7")));
+        onView(withId(R.id.description)).check(matches(withText("Description of the plot")));
+    }
+
+    private Object[] displaysSentimentValues() {
+        return new Object[] {
+            new Object[] {SentimentType.UNSPECIFIED, null, null},
+            new Object[] {SentimentType.THUMBS_UP, R.drawable.ic_baseline_thumb_up_24, null},
+            new Object[] {SentimentType.THUMBS_DOWN, null, R.drawable.ic_baseline_thumb_down_24}
+        };
+    }
+
+    @Test
+    @Parameters(method = "displaysSentimentValues")
+    public void detailsActivity_displaysSentiment(SentimentType sentimentType, Object thumbsUpIcon,
+                                                  Object thumbsDownIcon) {
+        AssetSentiment assetSentiment = AssetSentiment.create(
+                AssetUtil.createMovieAsset("assetId"), sentimentType);
+        Intent intent = new Intent();
+        intent.putExtra(AssetListFragment.EXTRA_ASSET_SENTIMENT, assetSentiment);
+
+        activityTestRule.launchActivity(intent);
+
+        onView(withId(R.id.thumbs_up)).check(matches(withTagValue(equalTo(thumbsUpIcon))));
+        onView(withId(R.id.thumbs_down)).check(matches(withTagValue(equalTo(thumbsDownIcon))));
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/details/DetailsActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/details/DetailsActivity.java
@@ -1,14 +1,66 @@
 package com.google.moviestvsentiments.usecase.details;
 
 import androidx.appcompat.app.AppCompatActivity;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.widget.ImageView;
+import android.widget.TextView;
+import com.bumptech.glide.Glide;
 import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.model.AssetSentiment;
+import com.google.moviestvsentiments.usecase.assetList.AssetListFragment;
 
+/**
+ * An Activity that displays the details of an AssetSentiment object. The AssetSentiment must
+ * be passed in the intent that launched the DetailsActivity.
+ */
 public class DetailsActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_details);
+
+        AssetSentiment assetSentiment = getIntent()
+                .getParcelableExtra(AssetListFragment.EXTRA_ASSET_SENTIMENT);
+        bind(assetSentiment);
+    }
+
+    /**
+     * Sets the various views in the DetailsActivity to display the information in the given
+     * AssetSentiment.
+     * @param assetSentiment The AssetSentiment to display.
+     */
+    private void bind(AssetSentiment assetSentiment) {
+        ImageView banner = findViewById(R.id.banner_image);
+        Glide.with(this).load(assetSentiment.asset().banner()).into(banner);
+
+        ImageView poster = findViewById(R.id.poster_image);
+        Glide.with(this).load(assetSentiment.asset().poster()).into(poster);
+
+        TextView title = findViewById(R.id.asset_title);
+        title.setText(assetSentiment.asset().title());
+
+        TextView rating = findViewById(R.id.rating);
+        rating.setText(assetSentiment.asset().imdbRating());
+
+        TextView description = findViewById(R.id.description);
+        description.setText(assetSentiment.asset().plot());
+
+        switch (assetSentiment.sentimentType()) {
+            case THUMBS_UP:
+                Drawable filledThumbUp = getDrawable(R.drawable.ic_baseline_thumb_up_24);
+                ImageView thumbsUp = findViewById(R.id.thumbs_up);
+                thumbsUp.setImageDrawable(filledThumbUp);
+                thumbsUp.setTag(R.drawable.ic_baseline_thumb_up_24);
+                break;
+            case THUMBS_DOWN:
+                Drawable filledThumbDown = getDrawable(R.drawable.ic_baseline_thumb_down_24);
+                ImageView thumbsDown = findViewById(R.id.thumbs_down);
+                thumbsDown.setImageDrawable(filledThumbDown);
+                thumbsDown.setTag(R.drawable.ic_baseline_thumb_down_24);
+                break;
+            default:
+        }
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/details/DetailsActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/details/DetailsActivity.java
@@ -61,6 +61,7 @@ public class DetailsActivity extends AppCompatActivity {
                 thumbsDown.setTag(R.drawable.ic_baseline_thumb_down_24);
                 break;
             default:
+                // by default the ImageViews start with the outlined images, so no action is needed
         }
     }
 }

--- a/MoviesTVSentiments/app/src/main/res/drawable/ic_outline_thumb_down_24.xml
+++ b/MoviesTVSentiments/app/src/main/res/drawable/ic_outline_thumb_down_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15,3L6,3c-0.83,0 -1.54,0.5 -1.84,1.22l-3.02,7.05c-0.09,0.23 -0.14,0.47 -0.14,0.73v2c0,1.1 0.9,2 2,2h6.31l-0.95,4.57 -0.03,0.32c0,0.41 0.17,0.79 0.44,1.06L9.83,23l6.59,-6.59c0.36,-0.36 0.58,-0.86 0.58,-1.41L17,5c0,-1.1 -0.9,-2 -2,-2zM15,15l-4.34,4.34L12,14L3,14v-2l3,-7h9v10zM19,3h4v12h-4z"/>
+</vector>

--- a/MoviesTVSentiments/app/src/main/res/drawable/ic_outline_thumb_up_24.xml
+++ b/MoviesTVSentiments/app/src/main/res/drawable/ic_outline_thumb_up_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M9,21h9c0.83,0 1.54,-0.5 1.84,-1.22l3.02,-7.05c0.09,-0.23 0.14,-0.47 0.14,-0.73v-2c0,-1.1 -0.9,-2 -2,-2h-6.31l0.95,-4.57 0.03,-0.32c0,-0.41 -0.17,-0.79 -0.44,-1.06L14.17,1 7.58,7.59C7.22,7.95 7,8.45 7,9v10c0,1.1 0.9,2 2,2zM9,9l4.34,-4.34L12,10h9v2l-3,7H9V9zM1,9h4v12H1z"/>
+</vector>

--- a/MoviesTVSentiments/app/src/main/res/layouts/details/layout/activity_details.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/details/layout/activity_details.xml
@@ -17,7 +17,6 @@
         android:id="@+id/banner_image"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:background="#AE2020"
         android:scaleType="centerCrop"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -39,7 +38,6 @@
         android:layout_height="200dp"
         android:layout_marginStart="32dp"
         android:layout_marginLeft="32dp"
-        android:background="#6E6565"
         android:scaleType="centerCrop"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/poster_margin_space" />
@@ -102,7 +100,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:src="@drawable/ic_baseline_thumb_up_24"
+        android:src="@drawable/ic_outline_thumb_up_24"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/top_line"
         app:layout_constraintEnd_toStartOf="@+id/center_guideline"/>
@@ -112,7 +110,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:src="@drawable/ic_baseline_thumb_down_24"
+        android:src="@drawable/ic_outline_thumb_down_24"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="@+id/center_guideline"
         app:layout_constraintTop_toBottomOf="@+id/top_line" />

--- a/MoviesTVSentiments/app/src/test-common/java/com/google/moviestvsentiments/util/AssetUtil.java
+++ b/MoviesTVSentiments/app/src/test-common/java/com/google/moviestvsentiments/util/AssetUtil.java
@@ -27,9 +27,7 @@ public class AssetUtil {
      * @return A movie asset with the given id.
      */
     public static Asset createMovieAsset(String assetId) {
-        return Asset.builder().setId(assetId).setType(AssetType.MOVIE).setTitle("assetTitle")
-                .setPoster("posterURL").setBanner("bannerURL").setPlot("plotDescription")
-                .setRuntime("runtime").setYear("year").setTimestamp(1).build();
+        return defaultMovieBuilder(assetId).build();
     }
 
     /**
@@ -41,5 +39,16 @@ public class AssetUtil {
         return Asset.builder().setId(assetId).setType(AssetType.SHOW).setTitle("assetTitle")
                 .setPoster("posterURL").setBanner("bannerURL").setYear("year")
                 .setPlot("plotDescription").setRuntime("runtime").setTimestamp(1).build();
+    }
+
+    /**
+     * Returns the default Asset Builder object for a movie asset with the given asset id.
+     * @param assetId The id of the asset to create.
+     * @return The default Asset Builder object for a movie asset with the given asset id.
+     */
+    public static Asset.Builder defaultMovieBuilder(String assetId) {
+        return Asset.builder().setId(assetId).setType(AssetType.MOVIE).setTitle("assetTitle")
+                .setPoster("posterURL").setBanner("bannerURL").setPlot("plotDescription")
+                .setRuntime("runtime").setYear("year").setTimestamp(1);
     }
 }


### PR DESCRIPTION
Displays the AssetSentiment data in the DetailsActivity. Glide is used again to load the banner and poster images. The thumbs up and down icons are filled in or outlined depending on the user sentiment toward the asset. No interactivity is added yet.