### PR TITLE
Update sentiment value from DetailsActivity

### DIFF
--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragmentTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragmentTest.java
@@ -161,9 +161,12 @@ public class AssetListFragmentTest {
     @Test
     @Parameters(method = "sendsIntentToDetailsActivityValues")
     public void assetListFragment_clickAsset_sendsIntentToDetailsActivity(AssetType assetType) {
+        final String accountName = "Test Account";
         Asset asset = AssetUtil.createAsset("assetId1", assetType);
         database.assetSentimentDao().addAsset(asset);
-        HiltFragmentScenario.launchHiltFragment(AssetListFragment.class,
+        Intent intent = new Intent(ApplicationProvider.getApplicationContext(), HiltTestActivity.class);
+        intent.putExtra(SigninActivity.EXTRA_ACCOUNT_NAME, accountName);
+        HiltFragmentScenario.launchHiltFragmentWithIntent(AssetListFragment.class, intent,
                 createFragmentArgs(SentimentType.UNSPECIFIED));
         Intents.init();
 
@@ -171,6 +174,7 @@ public class AssetListFragmentTest {
 
         intended(allOf(
             hasComponent(DetailsActivity.class.getName()),
+            hasExtra(AssetListFragment.EXTRA_ACCOUNT_NAME, accountName),
             hasExtra(AssetListFragment.EXTRA_ASSET_SENTIMENT, AssetSentiment.create(asset,
                     SentimentType.UNSPECIFIED))
         ));

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/details/DetailsActivityTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/details/DetailsActivityTest.java
@@ -1,36 +1,54 @@
 package com.google.moviestvsentiments.usecase.details;
 
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static com.google.common.truth.Truth.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import android.content.Intent;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.test.rule.ActivityTestRule;
 import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.di.DatabaseModule;
 import com.google.moviestvsentiments.model.Asset;
 import com.google.moviestvsentiments.model.AssetSentiment;
+import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
+import com.google.moviestvsentiments.service.assetSentiment.AssetSentimentDao;
 import com.google.moviestvsentiments.usecase.assetList.AssetListFragment;
 import com.google.moviestvsentiments.util.AssetUtil;
+import com.google.moviestvsentiments.util.LiveDataTestUtil;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
+import javax.inject.Inject;
+import dagger.hilt.android.testing.HiltAndroidRule;
+import dagger.hilt.android.testing.HiltAndroidTest;
+import dagger.hilt.android.testing.UninstallModules;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 
+@HiltAndroidTest
+@UninstallModules(DatabaseModule.class)
 @RunWith(JUnitParamsRunner.class)
 public class DetailsActivityTest {
 
-    @Rule
-    public ActivityTestRule<DetailsActivity> activityTestRule =
+    private ActivityTestRule<DetailsActivity> activityTestRule =
             new ActivityTestRule<>(DetailsActivity.class, false, false);
 
+    private HiltAndroidRule hiltTestRule = new HiltAndroidRule(this);
+
     @Rule
-    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+    public RuleChain ruleChain = RuleChain.outerRule(hiltTestRule).around(activityTestRule)
+            .around(new InstantTaskExecutorRule());
+
+    @Inject
+    AssetSentimentDao assetSentimentDao;
 
     private Object[] displaysAssetInfoValues() {
         return new Object[] {
@@ -61,16 +79,19 @@ public class DetailsActivityTest {
 
     private Object[] displaysSentimentValues() {
         return new Object[] {
-            new Object[] {SentimentType.UNSPECIFIED, null, null},
-            new Object[] {SentimentType.THUMBS_UP, R.drawable.ic_baseline_thumb_up_24, null},
-            new Object[] {SentimentType.THUMBS_DOWN, null, R.drawable.ic_baseline_thumb_down_24}
+            new Object[] {SentimentType.UNSPECIFIED, R.drawable.ic_outline_thumb_up_24,
+                    R.drawable.ic_outline_thumb_down_24},
+            new Object[] {SentimentType.THUMBS_UP, R.drawable.ic_baseline_thumb_up_24,
+                    R.drawable.ic_outline_thumb_down_24},
+            new Object[] {SentimentType.THUMBS_DOWN, R.drawable.ic_outline_thumb_up_24,
+                    R.drawable.ic_baseline_thumb_down_24}
         };
     }
 
     @Test
     @Parameters(method = "displaysSentimentValues")
-    public void detailsActivity_displaysSentiment(SentimentType sentimentType, Object thumbsUpIcon,
-                                                  Object thumbsDownIcon) {
+    public void detailsActivity_displaysSentiment(SentimentType sentimentType, int thumbsUpIcon,
+                                                  int thumbsDownIcon) {
         AssetSentiment assetSentiment = AssetSentiment.create(
                 AssetUtil.createMovieAsset("assetId"), sentimentType);
         Intent intent = new Intent();
@@ -80,5 +101,72 @@ public class DetailsActivityTest {
 
         onView(withId(R.id.thumbs_up)).check(matches(withTagValue(equalTo(thumbsUpIcon))));
         onView(withId(R.id.thumbs_down)).check(matches(withTagValue(equalTo(thumbsDownIcon))));
+    }
+
+    private Object[] changeSentiment_updatesDisplayValues() {
+        return new Object[] {
+            new Object[] {SentimentType.UNSPECIFIED, R.id.thumbs_up,
+                    R.drawable.ic_baseline_thumb_up_24, R.drawable.ic_outline_thumb_down_24},
+            new Object[] {SentimentType.UNSPECIFIED, R.id.thumbs_down,
+                    R.drawable.ic_outline_thumb_up_24, R.drawable.ic_baseline_thumb_down_24},
+            new Object[] {SentimentType.THUMBS_UP, R.id.thumbs_up,
+                    R.drawable.ic_outline_thumb_up_24, R.drawable.ic_outline_thumb_down_24},
+            new Object[] {SentimentType.THUMBS_UP, R.id.thumbs_down,
+                    R.drawable.ic_outline_thumb_up_24, R.drawable.ic_baseline_thumb_down_24},
+            new Object[] {SentimentType.THUMBS_DOWN, R.id.thumbs_up,
+                    R.drawable.ic_baseline_thumb_up_24, R.drawable.ic_outline_thumb_down_24},
+            new Object[] {SentimentType.THUMBS_DOWN, R.id.thumbs_down,
+                    R.drawable.ic_outline_thumb_up_24, R.drawable.ic_outline_thumb_down_24},
+        };
+    }
+
+    @Test
+    @Parameters(method = "changeSentiment_updatesDisplayValues")
+    public void detailsActivity_changeSentiment_updatesDisplay(SentimentType originalSentiment,
+                                   int iconToClick, int thumpUpDrawable, int thumbDownDrawable) {
+        AssetSentiment assetSentiment = AssetSentiment.create(
+                AssetUtil.createMovieAsset("assetId"), originalSentiment);
+        Intent intent = new Intent();
+        intent.putExtra(AssetListFragment.EXTRA_ACCOUNT_NAME, "accountName");
+        intent.putExtra(AssetListFragment.EXTRA_ASSET_SENTIMENT, assetSentiment);
+        activityTestRule.launchActivity(intent);
+
+        onView(withId(iconToClick)).perform(click());
+
+        onView(withId(R.id.thumbs_up)).check(matches(withTagValue(equalTo(thumpUpDrawable))));
+        onView(withId(R.id.thumbs_down)).check(matches(withTagValue(equalTo(thumbDownDrawable))));
+    }
+
+    private Object[] changeSentiment_updatesDatabaseValues() {
+        return new Object[] {
+            new Object[] {SentimentType.UNSPECIFIED, R.id.thumbs_up, SentimentType.THUMBS_UP},
+            new Object[] {SentimentType.UNSPECIFIED, R.id.thumbs_down, SentimentType.THUMBS_DOWN},
+            new Object[] {SentimentType.THUMBS_UP, R.id.thumbs_up, SentimentType.UNSPECIFIED},
+            new Object[] {SentimentType.THUMBS_UP, R.id.thumbs_down, SentimentType.THUMBS_DOWN},
+            new Object[] {SentimentType.THUMBS_DOWN, R.id.thumbs_up, SentimentType.THUMBS_UP},
+            new Object[] {SentimentType.THUMBS_DOWN, R.id.thumbs_down, SentimentType.UNSPECIFIED}
+        };
+    }
+
+    @Test
+    @Parameters(method = "changeSentiment_updatesDatabaseValues")
+    public void detailsActivity_changeSentiment_updatesDatabase(SentimentType originalSentiment,
+                                                    int iconToClick, SentimentType finalSentiment) {
+        final String accountName = "Account Name";
+        final String assetId = "assetId";
+        hiltTestRule.inject();
+        Asset asset = AssetUtil.createMovieAsset(assetId);
+        assetSentimentDao.addAsset(asset);
+        AssetSentiment assetSentiment = AssetSentiment.create(asset, originalSentiment);
+        Intent intent = new Intent();
+        intent.putExtra(AssetListFragment.EXTRA_ACCOUNT_NAME, accountName);
+        intent.putExtra(AssetListFragment.EXTRA_ASSET_SENTIMENT, assetSentiment);
+        activityTestRule.launchActivity(intent);
+
+        onView(withId(iconToClick)).perform(click());
+
+        assetSentiment = LiveDataTestUtil.getValue(assetSentimentDao.getAsset(accountName, assetId,
+                AssetType.MOVIE));
+        assertThat(assetSentiment).isEqualTo(AssetSentiment.create(asset, finalSentiment));
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragment.java
@@ -24,10 +24,13 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class AssetListFragment extends Fragment implements AssetListAdapter.AssetClickListener {
 
+    public static final String EXTRA_ACCOUNT_NAME = "com.google.moviestvsentiments.ACCOUNT_NAME";
     public static final String EXTRA_ASSET_SENTIMENT = "com.google.moviestvsentiments.ASSET_SENTIMENT";
 
     @Inject
     AssetSentimentViewModel viewModel;
+
+    private String accountName;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
@@ -36,7 +39,7 @@ public class AssetListFragment extends Fragment implements AssetListAdapter.Asse
         AssetListScreen assetListScreen = AssetListScreen.create(this, root,
                 container.getContext());
 
-        String accountName = getActivity().getIntent().getStringExtra(SigninActivity.EXTRA_ACCOUNT_NAME);
+        accountName = getActivity().getIntent().getStringExtra(SigninActivity.EXTRA_ACCOUNT_NAME);
         SentimentType sentimentType = AssetListFragmentArgs.fromBundle(getArguments())
                 .getSentimentType();
         viewModel.getAssets(AssetType.MOVIE, accountName, sentimentType)
@@ -48,12 +51,14 @@ public class AssetListFragment extends Fragment implements AssetListAdapter.Asse
     }
 
     /**
-     * Sends an intent containing the given AssetSentiment object to the DetailsActivity.
+     * Sends an intent containing the current account name and the given AssetSentiment object to
+     * the DetailsActivity.
      * @param assetSentiment The AssetSentiment object to pass to the DetailsActivity.
      */
     @Override
     public void onAssetClick(AssetSentiment assetSentiment) {
         Intent intent = new Intent(getContext(), DetailsActivity.class);
+        intent.putExtra(EXTRA_ACCOUNT_NAME, accountName);
         intent.putExtra(EXTRA_ASSET_SENTIMENT, assetSentiment);
         startActivity(intent);
     }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/details/DetailsActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/details/DetailsActivity.java
@@ -3,35 +3,47 @@ package com.google.moviestvsentiments.usecase.details;
 import androidx.appcompat.app.AppCompatActivity;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 import com.bumptech.glide.Glide;
 import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.model.Asset;
 import com.google.moviestvsentiments.model.AssetSentiment;
+import com.google.moviestvsentiments.model.SentimentType;
+import com.google.moviestvsentiments.service.assetSentiment.AssetSentimentViewModel;
 import com.google.moviestvsentiments.usecase.assetList.AssetListFragment;
+import javax.inject.Inject;
+import dagger.hilt.android.AndroidEntryPoint;
 
 /**
  * An Activity that displays the details of an AssetSentiment object. The AssetSentiment must
  * be passed in the intent that launched the DetailsActivity.
  */
-public class DetailsActivity extends AppCompatActivity {
+@AndroidEntryPoint
+public class DetailsActivity extends AppCompatActivity implements View.OnClickListener {
+
+    @Inject
+    AssetSentimentViewModel viewModel;
+
+    private String accountName;
+    private AssetSentiment assetSentiment;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_details);
 
-        AssetSentiment assetSentiment = getIntent()
-                .getParcelableExtra(AssetListFragment.EXTRA_ASSET_SENTIMENT);
-        bind(assetSentiment);
+        accountName = getIntent().getStringExtra(AssetListFragment.EXTRA_ACCOUNT_NAME);
+        assetSentiment = getIntent().getParcelableExtra(AssetListFragment.EXTRA_ASSET_SENTIMENT);
+        bind();
     }
 
     /**
      * Sets the various views in the DetailsActivity to display the information in the given
-     * AssetSentiment.
-     * @param assetSentiment The AssetSentiment to display.
+     * AssetSentiment and sets the onClickListener for the thumbs up and thumbs down ImageViews.
      */
-    private void bind(AssetSentiment assetSentiment) {
+    private void bind() {
         ImageView banner = findViewById(R.id.banner_image);
         Glide.with(this).load(assetSentiment.asset().banner()).into(banner);
 
@@ -47,21 +59,91 @@ public class DetailsActivity extends AppCompatActivity {
         TextView description = findViewById(R.id.description);
         description.setText(assetSentiment.asset().plot());
 
+        ImageView thumbsUp = findViewById(R.id.thumbs_up);
+        thumbsUp.setOnClickListener(this);
+
+        ImageView thumbsDown = findViewById(R.id.thumbs_down);
+        thumbsDown.setOnClickListener(this);
+
+        bindSentimentImages();
+    }
+
+    /**
+     * Sets the icons displayed by the thumbs up and thumbs down ImageViews.
+     */
+    private void bindSentimentImages() {
+        ImageView thumbsUp = findViewById(R.id.thumbs_up);
+        ImageView thumbsDown = findViewById(R.id.thumbs_down);
+
         switch (assetSentiment.sentimentType()) {
             case THUMBS_UP:
                 Drawable filledThumbUp = getDrawable(R.drawable.ic_baseline_thumb_up_24);
-                ImageView thumbsUp = findViewById(R.id.thumbs_up);
                 thumbsUp.setImageDrawable(filledThumbUp);
                 thumbsUp.setTag(R.drawable.ic_baseline_thumb_up_24);
+
+                Drawable outlineThumbDown = getDrawable(R.drawable.ic_outline_thumb_down_24);
+                thumbsDown.setImageDrawable(outlineThumbDown);
+                thumbsDown.setTag(R.drawable.ic_outline_thumb_down_24);
                 break;
             case THUMBS_DOWN:
+                Drawable outlineThumbUp = getDrawable(R.drawable.ic_outline_thumb_up_24);
+                thumbsUp.setImageDrawable(outlineThumbUp);
+                thumbsUp.setTag(R.drawable.ic_outline_thumb_up_24);
+
                 Drawable filledThumbDown = getDrawable(R.drawable.ic_baseline_thumb_down_24);
-                ImageView thumbsDown = findViewById(R.id.thumbs_down);
                 thumbsDown.setImageDrawable(filledThumbDown);
                 thumbsDown.setTag(R.drawable.ic_baseline_thumb_down_24);
                 break;
+            case UNSPECIFIED:
+                outlineThumbUp = getDrawable(R.drawable.ic_outline_thumb_up_24);
+                thumbsUp.setImageDrawable(outlineThumbUp);
+                thumbsUp.setTag(R.drawable.ic_outline_thumb_up_24);
+
+                outlineThumbDown = getDrawable(R.drawable.ic_outline_thumb_down_24);
+                thumbsDown.setImageDrawable(outlineThumbDown);
+                thumbsDown.setTag(R.drawable.ic_outline_thumb_down_24);
+                break;
             default:
-                // by default the ImageViews start with the outlined images, so no action is needed
+                throw new AssertionError("SentimentType has no other possible values");
+        }
+    }
+
+    /**
+     * Handles click events from the thumbs up and thumbs down ImageViews. Updates the sentiment
+     * value stored in the database, as well as the assetSentiment instance variable and the icons
+     * displayed by the ImageViews.
+     * @param view The ImageView that was clicked.
+     */
+    @Override
+    public void onClick(View view) {
+        switch (view.getId()) {
+            case R.id.thumbs_up:
+                updateSentiment(SentimentType.THUMBS_UP);
+                break;
+            case R.id.thumbs_down:
+                updateSentiment(SentimentType.THUMBS_DOWN);
+                break;
+            default:
+                throw new AssertionError("Only the thumbs up and thumbs down image " +
+                        "views should be clickable");
+        }
+        bindSentimentImages();
+    }
+
+    /**
+     * Updates the sentiment value stored in the database, as well as the assetSentiment instance
+     * variable, to match the user's new sentiment value. If the clickedSentiment is equal to the
+     * current sentiment, then the new sentiment value will be UNSPECIFIED.
+     * @param clickedSentiment The SentimentType of the clicked reaction icon.
+     */
+    private void updateSentiment(SentimentType clickedSentiment) {
+        Asset asset = assetSentiment.asset();
+        if (assetSentiment.sentimentType() == clickedSentiment) {
+            viewModel.updateSentiment(accountName, asset.id(), asset.type(), SentimentType.UNSPECIFIED);
+            assetSentiment = AssetSentiment.create(asset, SentimentType.UNSPECIFIED);
+        } else {
+            viewModel.updateSentiment(accountName, asset.id(), asset.type(), clickedSentiment);
+            assetSentiment = AssetSentiment.create(asset, clickedSentiment);
         }
     }
 }


### PR DESCRIPTION
Updates the sentiment value for an asset when the thumbs up and thumbs down icons are clicked in the DetailsActivity. The AssetListFragment now passes the current account name to the DetailsActivity in order to support this functionality.