### PR TITLE
Add account endpoints to the server

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 .gradle
 build/
+bin/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**
 !**/src/test/**

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -13,7 +13,9 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.h2database:h2'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}

--- a/server/src/main/java/com/google/moviestvsentiments/account/Account.java
+++ b/server/src/main/java/com/google/moviestvsentiments/account/Account.java
@@ -2,6 +2,7 @@ package com.google.moviestvsentiments.account;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import java.time.Instant;
 import java.util.Objects;
 
 /**
@@ -12,12 +13,12 @@ public class Account {
     
     @Id
     private String accountName;
-    private long timestamp;
+    private Instant timestamp;
 
     // The default constructor is required by the Spring JPA.
     protected Account() {}
 
-    private Account(String accountName, long timestamp) {
+    private Account(String accountName, Instant timestamp) {
         this.accountName = accountName;
         this.timestamp = timestamp;
     }
@@ -28,7 +29,7 @@ public class Account {
      * @param timestamp The timestamp for the new account.
      * @return A new Account with the given name and timestamp.
      */
-    public static Account create(String accountName, long timestamp) {
+    public static Account create(String accountName, Instant timestamp) {
         return new Account(accountName, timestamp);
     }
 
@@ -50,7 +51,7 @@ public class Account {
     /**
      * Returns the account's timestamp.
      */
-    public long getTimestamp() {
+    public Instant getTimestamp() {
         return timestamp;
     }
 
@@ -58,7 +59,7 @@ public class Account {
      * Sets the account's timestamp.
      * @param timestamp The new timestamp for the account.
      */
-    public void setTimestamp(long timestamp) {
+    public void setTimestamp(Instant timestamp) {
         this.timestamp = timestamp;
     }
 
@@ -67,7 +68,7 @@ public class Account {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Account account = (Account) o;
-        return timestamp == account.timestamp &&
+        return timestamp.equals(account.timestamp) &&
                 accountName.equals(account.accountName);
     }
 

--- a/server/src/main/java/com/google/moviestvsentiments/account/Account.java
+++ b/server/src/main/java/com/google/moviestvsentiments/account/Account.java
@@ -1,0 +1,78 @@
+package com.google.moviestvsentiments.account;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.util.Objects;
+
+/**
+ * A record in the accounts database table.
+ */
+@Entity
+public class Account {
+    
+    @Id
+    private String accountName;
+    private long timestamp;
+
+    // The default constructor is required by the Spring JPA.
+    protected Account() {}
+
+    private Account(String accountName, long timestamp) {
+        this.accountName = accountName;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Creates a new Account with the given name and timestamp.
+     * @param accountName The name for the new account.
+     * @param timestamp The timestamp for the new account.
+     * @return A new Account with the given name and timestamp.
+     */
+    public static Account create(String accountName, long timestamp) {
+        return new Account(accountName, timestamp);
+    }
+
+    /**
+     * Returns the account name.
+     */
+    public String getAccountName() {
+        return accountName;
+    }
+
+    /**
+     * Sets the account name.
+     * @param accountName The new name for the account.
+     */
+    public void setAccountName(String accountName) {
+        this.accountName = accountName;
+    }
+
+    /**
+     * Returns the account's timestamp.
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Sets the account's timestamp.
+     * @param timestamp The new timestamp for the account.
+     */
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Account account = (Account) o;
+        return timestamp == account.timestamp &&
+                accountName.equals(account.accountName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountName, timestamp);
+    }
+}

--- a/server/src/main/java/com/google/moviestvsentiments/account/AccountController.java
+++ b/server/src/main/java/com/google/moviestvsentiments/account/AccountController.java
@@ -1,0 +1,54 @@
+package com.google.moviestvsentiments.account;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * A controller that handles requests related to accounts.
+ */
+@RestController
+public class AccountController {
+
+    @Autowired
+    private AccountRepository repository;
+
+    /**
+     * Returns a list of all accounts sorted in ascending order by account name.
+     */
+    @GetMapping("/accounts")
+    public List<Account> getAccounts() {
+        Iterable<Account> accounts = repository.findAll(Sort.by("accountName"));
+        return StreamSupport.stream(accounts.spliterator(), false).collect(Collectors.toList());
+    }
+
+    /**
+     * Adds the given list of accounts into the database. If the accounts are added successfully, the list of
+     * successfully created accounts is returned. If the accounts cannot be added, an error message is returned.
+     * @param accounts The list of accounts to add.
+     * @return A ResponseEntity with either the created accounts or the error message.
+     */
+    @PostMapping("/accounts")
+    public ResponseEntity<AddAccountResponse> addAccounts(@RequestBody List<Account> accounts) {
+        try {
+            Iterable<Account> iterable = repository.saveAll(accounts);
+            List<Account> savedAccounts = StreamSupport.stream(iterable.spliterator(), false)
+                    .collect(Collectors.toList());
+            return ResponseEntity.ok().body(AddAccountResponse.create(savedAccounts, null));
+        } catch (JpaSystemException e) {
+            return ResponseEntity.badRequest().body(AddAccountResponse.create(null, e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(AddAccountResponse.create(null, e.getMessage()));
+        }
+    }
+}

--- a/server/src/main/java/com/google/moviestvsentiments/account/AccountRepository.java
+++ b/server/src/main/java/com/google/moviestvsentiments/account/AccountRepository.java
@@ -1,0 +1,6 @@
+package com.google.moviestvsentiments.account;
+
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+public interface AccountRepository extends PagingAndSortingRepository<Account, String> {
+}

--- a/server/src/main/java/com/google/moviestvsentiments/account/AddAccountResponse.java
+++ b/server/src/main/java/com/google/moviestvsentiments/account/AddAccountResponse.java
@@ -1,0 +1,41 @@
+package com.google.moviestvsentiments.account;
+
+import java.util.List;
+
+/**
+ * Represents the response type for the add account endpoint.
+ */
+public class AddAccountResponse {
+
+    private List<Account> accounts;
+    private String error;
+
+    private AddAccountResponse(List<Account> accounts, String error) {
+        this.accounts = accounts;
+        this.error = error;
+    }
+
+    /**
+     * Creates a new AddAccountResponse with the given account list and error.
+     * @param accounts The list of accounts that were successfully created.
+     * @param error The error message that occurred when creating the accounts.
+     * @return A new AddAccountResponse with the given account list and error.
+     */
+    public static AddAccountResponse create(List<Account> accounts, String error) {
+        return new AddAccountResponse(accounts, error);
+    }
+
+    /**
+     * Returns the list of accounts that were created successfully.
+     */
+    public List<Account> getAccounts() {
+        return accounts;
+    }
+
+    /**
+     * Returns the message of the error that occurred when creating the accounts.
+     */
+    public String getError() {
+        return error;
+    }
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,1 +1,5 @@
-
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/server/src/test/java/com/google/moviestvsentiments/account/AccountControllerTest.java
+++ b/server/src/test/java/com/google/moviestvsentiments/account/AccountControllerTest.java
@@ -1,0 +1,115 @@
+package com.google.moviestvsentiments.account;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.test.web.servlet.MockMvc;
+import java.util.Arrays;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AccountControllerTest {
+
+    private static final Account ACCOUNT_1 = Account.create("Test Name 1", 0);
+    private static final Account ACCOUNT_2 = Account.create("Test Name 2", 1);
+    private static final String ACCOUNT_LIST_JSON = "[ { \"accountName\": \"Test Name 1\", \"timestamp\": 0 }, " +
+            "{\"accountName\": \"Test Name 2\", \"timestamp\": 1} ]";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AccountRepository mockRepository;
+
+    @Test
+    public void accountController_getAccounts_returnsAccounts() throws Exception {
+        when(mockRepository.findAll(any(Sort.class))).thenReturn(Arrays.asList(ACCOUNT_1, ACCOUNT_2));
+
+        mockMvc.perform(get("/accounts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].accountName", equalTo(ACCOUNT_1.getAccountName())))
+                .andExpect(jsonPath("$[0].timestamp", equalTo((int)ACCOUNT_1.getTimestamp())))
+                .andExpect(jsonPath("$[1].accountName", equalTo(ACCOUNT_2.getAccountName())))
+                .andExpect(jsonPath("$[1].timestamp", equalTo((int)ACCOUNT_2.getTimestamp())));
+    }
+
+    @Test
+    public void accountController_addAccounts_invokesRepository() throws Exception {
+        mockMvc.perform(post("/accounts").contentType(MediaType.APPLICATION_JSON).content(ACCOUNT_LIST_JSON));
+
+        verify(mockRepository).saveAll(Arrays.asList(ACCOUNT_1, ACCOUNT_2));
+    }
+
+    @Test
+    public void accountController_addAccountsSuccessful_returnsOk() throws Exception {
+        mockMvc.perform(post("/accounts").contentType(MediaType.APPLICATION_JSON).content(ACCOUNT_LIST_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void accountController_addAccountsSuccessful_returnsAccounts() throws Exception {
+        when(mockRepository.saveAll(any(Iterable.class))).thenReturn(Arrays.asList(ACCOUNT_1, ACCOUNT_2));
+
+        mockMvc.perform(post("/accounts").contentType(MediaType.APPLICATION_JSON).content(ACCOUNT_LIST_JSON))
+                .andExpect(jsonPath("$.accounts[0].accountName", equalTo(ACCOUNT_1.getAccountName())))
+                .andExpect(jsonPath("$.accounts[0].timestamp", equalTo((int)ACCOUNT_1.getTimestamp())))
+                .andExpect(jsonPath("$.accounts[1].accountName", equalTo(ACCOUNT_2.getAccountName())))
+                .andExpect(jsonPath("$.accounts[1].timestamp", equalTo((int)ACCOUNT_2.getTimestamp())));
+    }
+
+    @Test
+    public void accountController_addAccountsSuccessful_returnsNullError() throws Exception {
+        when(mockRepository.saveAll(any(Iterable.class))).thenReturn(Arrays.asList(ACCOUNT_1, ACCOUNT_2));
+
+        mockMvc.perform(post("/accounts").contentType(MediaType.APPLICATION_JSON).content(ACCOUNT_LIST_JSON))
+                .andExpect(jsonPath("$.error", equalTo(null)));
+    }
+
+    @Test
+    public void accountController_addAccountsJpaException_returnsBadRequest() throws Exception {
+        when(mockRepository.saveAll(any(Iterable.class))).thenThrow(JpaSystemException.class);
+
+        mockMvc.perform(post("/accounts").contentType(MediaType.APPLICATION_JSON).content(ACCOUNT_LIST_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void accountController_addAccountsOtherException_returnsServerError() throws Exception {
+        when(mockRepository.saveAll(any(Iterable.class))).thenThrow(RuntimeException.class);
+
+        mockMvc.perform(post("/accounts").contentType(MediaType.APPLICATION_JSON).content(ACCOUNT_LIST_JSON))
+                .andExpect(status().is5xxServerError());
+    }
+
+    @Test
+    public void accountController_addAccountsFailure_returnsNullList() throws Exception {
+        when(mockRepository.saveAll(any(Iterable.class))).thenThrow(JpaSystemException.class);
+
+        mockMvc.perform(post("/accounts").contentType(MediaType.APPLICATION_JSON).content(ACCOUNT_LIST_JSON))
+                .andExpect(jsonPath("$.accounts", equalTo(null)));
+    }
+
+    @Test
+    public void accountController_addAccountsFailure_returnsError() throws Exception {
+        final String errorMessage = "Invalid account name";
+        when(mockRepository.saveAll(any(Iterable.class))).thenThrow(new JpaSystemException(new RuntimeException(errorMessage)));
+
+        mockMvc.perform(post("/accounts").contentType(MediaType.APPLICATION_JSON).content(ACCOUNT_LIST_JSON))
+                .andExpect(jsonPath("$.error", containsString(errorMessage)));
+    }
+}

--- a/server/src/test/java/com/google/moviestvsentiments/account/AccountControllerTest.java
+++ b/server/src/test/java/com/google/moviestvsentiments/account/AccountControllerTest.java
@@ -18,14 +18,15 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.test.web.servlet.MockMvc;
+import java.time.Instant;
 import java.util.Arrays;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 public class AccountControllerTest {
 
-    private static final Account ACCOUNT_1 = Account.create("Test Name 1", 0);
-    private static final Account ACCOUNT_2 = Account.create("Test Name 2", 1);
+    private static final Account ACCOUNT_1 = Account.create("Test Name 1", Instant.ofEpochSecond(0));
+    private static final Account ACCOUNT_2 = Account.create("Test Name 2", Instant.ofEpochSecond(1));
     private static final String ACCOUNT_LIST_JSON = "[ { \"accountName\": \"Test Name 1\", \"timestamp\": 0 }, " +
             "{\"accountName\": \"Test Name 2\", \"timestamp\": 1} ]";
 
@@ -43,9 +44,9 @@ public class AccountControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(2)))
                 .andExpect(jsonPath("$[0].accountName", equalTo(ACCOUNT_1.getAccountName())))
-                .andExpect(jsonPath("$[0].timestamp", equalTo((int)ACCOUNT_1.getTimestamp())))
+                .andExpect(jsonPath("$[0].timestamp", equalTo(ACCOUNT_1.getTimestamp().toString())))
                 .andExpect(jsonPath("$[1].accountName", equalTo(ACCOUNT_2.getAccountName())))
-                .andExpect(jsonPath("$[1].timestamp", equalTo((int)ACCOUNT_2.getTimestamp())));
+                .andExpect(jsonPath("$[1].timestamp", equalTo(ACCOUNT_2.getTimestamp().toString())));
     }
 
     @Test
@@ -67,9 +68,9 @@ public class AccountControllerTest {
 
         mockMvc.perform(post("/accounts").contentType(MediaType.APPLICATION_JSON).content(ACCOUNT_LIST_JSON))
                 .andExpect(jsonPath("$.accounts[0].accountName", equalTo(ACCOUNT_1.getAccountName())))
-                .andExpect(jsonPath("$.accounts[0].timestamp", equalTo((int)ACCOUNT_1.getTimestamp())))
+                .andExpect(jsonPath("$.accounts[0].timestamp", equalTo(ACCOUNT_1.getTimestamp().toString())))
                 .andExpect(jsonPath("$.accounts[1].accountName", equalTo(ACCOUNT_2.getAccountName())))
-                .andExpect(jsonPath("$.accounts[1].timestamp", equalTo((int)ACCOUNT_2.getTimestamp())));
+                .andExpect(jsonPath("$.accounts[1].timestamp", equalTo(ACCOUNT_2.getTimestamp().toString())));
     }
 
     @Test


### PR DESCRIPTION
Adds the GET /accounts and POST /accounts endpoints to the server, as well as tests for both endpoints. The account data is stored in an in-memory database that is cleared every time the server restarts.