### PR TITLE
Add server tests and app test coverage to CI

### DIFF
--- a/.github/workflows/test-workflow.yaml
+++ b/.github/workflows/test-workflow.yaml
@@ -14,11 +14,7 @@ jobs:
         with:
           java-version: 1.8      
 
-      - name: Run JUnit tests
-        run: bash ./gradlew test
-        working-directory: ./MoviesTVSentiments
-
-      - name: Run Espresso tests
+      - name: Run app JUnit and Espresso tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           working-directory: ./MoviesTVSentiments
@@ -26,11 +22,20 @@ jobs:
           script: |
             adb logcat -c
             adb logcat *:E &
-            ./gradlew connectedAndroidTest
+            ./gradlew jacocoTestReport
 
-      - name: Upload test report
+      - name: Upload app test report
         uses: actions/upload-artifact@v2
-        if: failure()
         with:
-          name: test-report
-          path: /Users/runner/work/play-movies-2020-intern/play-movies-2020-intern/MoviesTVSentiments/app/build/reports/androidTests/connected/ 
+          name: app-test-report
+          path: /Users/runner/work/play-movies-2020-intern/play-movies-2020-intern/MoviesTVSentiments/app/build/reports/
+
+      - name: Run server JUnit tests
+        run: bash ./gradlew test
+        working-directory: ./server
+ 
+      - name: Upload server test report
+        uses: actions/upload-artifact@v2
+        with:
+          name: server-test-report
+          path: /Users/runner/work/play-movies-2020-intern/play-movies-2020-intern/server/build/reports/tests/test/

--- a/.github/workflows/test-workflow.yaml
+++ b/.github/workflows/test-workflow.yaml
@@ -14,8 +14,20 @@ jobs:
         with:
           java-version: 1.8      
 
+      - name: Run server JUnit tests
+        run: bash ./gradlew test
+        working-directory: ./server
+ 
+      - name: Upload server test report
+        uses: actions/upload-artifact@v2
+        if: ${{ !cancelled() }}
+        with:
+          name: server-test-report
+          path: /Users/runner/work/play-movies-2020-intern/play-movies-2020-intern/server/build/reports/tests/test/
+
       - name: Run app JUnit and Espresso tests
         uses: reactivecircus/android-emulator-runner@v2
+        if: ${{ !cancelled() }}
         with:
           working-directory: ./MoviesTVSentiments
           api-level: 29
@@ -26,16 +38,8 @@ jobs:
 
       - name: Upload app test report
         uses: actions/upload-artifact@v2
+        if: ${{ !cancelled() }}
         with:
           name: app-test-report
           path: /Users/runner/work/play-movies-2020-intern/play-movies-2020-intern/MoviesTVSentiments/app/build/reports/
 
-      - name: Run server JUnit tests
-        run: bash ./gradlew test
-        working-directory: ./server
- 
-      - name: Upload server test report
-        uses: actions/upload-artifact@v2
-        with:
-          name: server-test-report
-          path: /Users/runner/work/play-movies-2020-intern/play-movies-2020-intern/server/build/reports/tests/test/

--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -1,6 +1,11 @@
 apply plugin: 'com.android.application'
 apply plugin: 'dagger.hilt.android.plugin'
 apply plugin: "androidx.navigation.safeargs"
+apply plugin: "jacoco"
+
+jacoco {
+    toolVersion = "$jacocoVersion"
+}
 
 android {
     compileSdkVersion 29
@@ -17,6 +22,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
@@ -37,6 +45,13 @@ android {
         androidTest.java.srcDirs += "src/test-common/java"
         test.java.srcDirs += "src/test-common/java"
     }
+
+    testOptions {
+        animationsDisabled true
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 tasks.withType(Test) {
@@ -45,6 +60,21 @@ tasks.withType(Test) {
         events "skipped", "passed", "failed"
         showStandardStreams true
     }
+}
+
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    def mainSrc = "$project.projectDir/src/main/java"
+    sourceDirectories.setFrom files([mainSrc])
+    classDirectories.setFrom files([mainSrc])
+    executionData.setFrom fileTree(dir: mainSrc, includes: [
+            'jacoco/testDebugUnitTest.exec', 'outputs/code_coverage/debugAndroidTest/connected/**/*.ec'
+    ])
 }
 
 dependencies {

--- a/MoviesTVSentiments/build.gradle
+++ b/MoviesTVSentiments/build.gradle
@@ -6,10 +6,12 @@ buildscript {
     }
 
     ext.hiltVersion = '2.28-alpha'
+    ext.jacocoVersion = '0.8.4'
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0-rc01'
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hiltVersion"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.0"
+        classpath "org.jacoco:org.jacoco.core:$jacocoVersion"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Adds the server unit tests to the CI workflow. Also combines the app's unit and instrumented tests into a single step and produces a test coverage report for that step.