### PR TITLE
Scrape Assets from OMDB

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -19,6 +19,8 @@ dependencies {
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
+	implementation 'net.sourceforge.htmlunit:htmlunit'
+	compile 'com.google.api-client:google-api-client:1.30.9'
 }
 
 test {

--- a/server/src/main/java/com/google/moviestvsentiments/assetSentiment/Asset.java
+++ b/server/src/main/java/com/google/moviestvsentiments/assetSentiment/Asset.java
@@ -3,6 +3,7 @@ package com.google.moviestvsentiments.assetSentiment;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.Lob;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Objects;
@@ -67,7 +68,7 @@ public class Asset {
     private String banner;
     private String imdbRating;
     private String rottenTomatoesRating;
-    private String plot;
+    @Lob private String plot;
     private String runtime;
     private String year;
     private Instant timestamp;

--- a/server/src/main/java/com/google/moviestvsentiments/webscrape/AssetScrapeController.java
+++ b/server/src/main/java/com/google/moviestvsentiments/webscrape/AssetScrapeController.java
@@ -1,0 +1,44 @@
+package com.google.moviestvsentiments.webscrape;
+
+import com.google.moviestvsentiments.assetSentiment.Asset;
+import com.google.moviestvsentiments.assetSentiment.AssetSentimentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+/**
+ * A controller that handles requests related to scraping Assets from OMDB.
+ */
+@RestController
+public class AssetScrapeController {
+
+    @Autowired
+    private AssetSentimentRepository assetSentimentRepository;
+
+    @Autowired
+    private AssetScraper assetScraper;
+
+    /**
+     * Scrapes Assets listed at the given url and saves them in the Assets database table. The url should point to an
+     * IMDB page listing Assets. If an error occurs, the error message is returned.
+     * @param url The IMDB page listing the Assets and their ids.
+     * @param apiKey The OMDB api key to use when fetching Asset details.
+     * @return A ResponseEntity containing the error message, if an error occurs.
+     */
+    @GetMapping("/scrape")
+    public ResponseEntity<String> scrapeAssets(@RequestParam("url") String url,
+                                       @RequestParam("apiKey") String apiKey) {
+        try {
+            List<String> assetIds = assetScraper.scrapeIds(url);
+            List<Asset> assets = assetScraper.scrapeAssets(assetIds, apiKey);
+            assetSentimentRepository.saveAll(assets);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+    }
+}

--- a/server/src/main/java/com/google/moviestvsentiments/webscrape/AssetScraper.java
+++ b/server/src/main/java/com/google/moviestvsentiments/webscrape/AssetScraper.java
@@ -1,0 +1,152 @@
+package com.google.moviestvsentiments.webscrape;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlAnchor;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.google.api.client.http.*;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.JsonObjectParser;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.Key;
+import com.google.moviestvsentiments.assetSentiment.Asset;
+import com.google.moviestvsentiments.assetSentiment.AssetType;
+import org.springframework.context.annotation.Configuration;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Provides functions to support scraping Assets from OMDB.
+ */
+@Configuration
+public class AssetScraper {
+
+    /**
+     * Represents a response from the OMDB API.
+     */
+    public static class OmdbResponse {
+
+        public static class Rating {
+            @Key("Source") public String source;
+            @Key("Value") public String value;
+        }
+
+        @Key("imdbID") public String assetId;
+        @Key("Type") public String assetType;
+        @Key("Title") public String title;
+        @Key("Poster") public String poster;
+        @Key public String imdbRating;
+        @Key("Ratings") List<Rating> ratings;
+        @Key("Plot") public String plot;
+        @Key("Runtime") public String runtime;
+        @Key("Year") public String year;
+    }
+
+    private static final String IMDB_ASSET_XPATH = "//td[@class='titleColumn']/a";
+    private static final String IMDB_ASSET_URL_PREFIX = "/title/";
+    private static final String OMDB_MOVIE_TYPE = "movie";
+    private static final String OMDB_SHOW_TYPE = "series";
+    private static final String OMDB_ROTTEN_TOMATOES_SOURCE = "Rotten Tomatoes";
+
+    private final Clock clock;
+    private final HttpRequestFactory requestFactory;
+
+    // Public default constructor is required for Spring to autowire AssetScraper in AssetScrapeController.
+    public AssetScraper() {
+        clock = Clock.systemUTC();
+        requestFactory = defaultRequestFactory();
+    }
+
+    /**
+     * Returns the default HttpRequestFactory that uses NetHttpTransport to send HTTP requests and Jackson to parse
+     * JSON responses.
+     */
+    private static HttpRequestFactory defaultRequestFactory() {
+        HttpTransport httpTransport = new NetHttpTransport();
+        JsonFactory jsonFactory = new JacksonFactory();
+        return httpTransport.createRequestFactory(new HttpRequestInitializer() {
+            @Override
+            public void initialize(HttpRequest request) {
+                request.setParser(new JsonObjectParser(jsonFactory));
+            }
+        });
+    }
+
+    /**
+     * Returns a list of IMDB asset ids scraped from the provided url.
+     * @param url The url of the IMDB page to scrape asset ids from.
+     * @return A list of IDMB asset ids.
+     * @throws IOException If fetching the page at the given url fails.
+     */
+    public List<String> scrapeIds(String url) throws IOException {
+        WebClient client = new WebClient();
+        client.getOptions().setCssEnabled(false);
+        client.getOptions().setJavaScriptEnabled(false);
+        HtmlPage page = client.getPage(url);
+        List<HtmlAnchor> assetLinks = page.getByXPath(IMDB_ASSET_XPATH);
+
+        List<String> assetIds = new ArrayList<>();
+        for (HtmlAnchor assetLink : assetLinks) {
+            String assetUrl = assetLink.getHrefAttribute();
+            int startPosition = IMDB_ASSET_URL_PREFIX.length();
+            int endPosition = assetUrl.lastIndexOf("/");
+            assetIds.add(assetUrl.substring(startPosition, endPosition));
+        }
+        return assetIds;
+    }
+
+    /**
+     * Returns a list of Assets scraped from OMDB. The given OMDB api key and the list of Asset ids is used to query
+     * OMDB for the Assets.
+     * @param assetIds The list of Asset ids to query OMDB for.
+     * @param omdbApiKey The api key to use when querying OMDB.
+     * @return A list of Assets scraped from OMDB.
+     * @throws IOException If the OMDB query fails.
+     */
+    public List<Asset> scrapeAssets(List<String> assetIds, String omdbApiKey) throws IOException {
+        List<Asset> assets = new ArrayList<>();
+        for (String assetId : assetIds) {
+            String url = "http://www.omdbapi.com/?plot=full&apikey=" + omdbApiKey + "&i=" + assetId;
+            HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(url));
+            OmdbResponse response = request.execute().parseAs(OmdbResponse.class);
+            assets.add(createAsset(response));
+        }
+        return assets;
+    }
+
+    /**
+     * Creates a new Asset from the given OmdbResponse. The Asset's timestamp is set to the current time.
+     * @param omdbResponse The OmdbResponse to use when creating the Asset.
+     * @return A new Asset created using the OmdbResponse.
+     */
+    private Asset createAsset(OmdbResponse omdbResponse) {
+        Asset asset = new Asset();
+        asset.setAssetId(omdbResponse.assetId);
+        asset.setTitle(omdbResponse.title);
+        asset.setPoster(omdbResponse.poster);
+        asset.setImdbRating(omdbResponse.imdbRating);
+        asset.setPlot(omdbResponse.plot);
+        asset.setRuntime(omdbResponse.runtime);
+        asset.setYear(omdbResponse.year);
+        asset.setTimestamp(Instant.now(clock));
+
+        if (OMDB_MOVIE_TYPE.equals(omdbResponse.assetType)) {
+            asset.setAssetType(AssetType.MOVIE);
+        } else if (OMDB_SHOW_TYPE.equals(omdbResponse.assetType)) {
+            asset.setAssetType(AssetType.SHOW);
+        } else {
+            throw new AssertionError("Unknown OMDB asset type: " + omdbResponse.assetType);
+        }
+
+        for (OmdbResponse.Rating rating : omdbResponse.ratings) {
+            if (OMDB_ROTTEN_TOMATOES_SOURCE.equals(rating.source)) {
+                asset.setRottenTomatoesRating(rating.value);
+            }
+        }
+
+        return asset;
+    }
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,5 +1,6 @@
-spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.url=jdbc:h2:file:~/moviestvsentiments-db
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update

--- a/server/src/test/java/com/google/moviestvsentiments/AssetUtil.java
+++ b/server/src/test/java/com/google/moviestvsentiments/AssetUtil.java
@@ -1,0 +1,25 @@
+package com.google.moviestvsentiments;
+
+import com.google.moviestvsentiments.assetSentiment.Asset;
+import com.google.moviestvsentiments.assetSentiment.AssetType;
+
+/**
+ * Provides helper functions for working with Assets in tests.
+ */
+public class AssetUtil {
+
+    /**
+     * Creates a new Asset with the provided id, type and title.
+     * @param assetId The id of the new Asset.
+     * @param assetType The type of the new Asset.
+     * @param title The title of the new Asset.
+     * @return A new Asset with the provided id, type and title.
+     */
+    public static Asset createAsset(String assetId, AssetType assetType, String title) {
+        Asset asset = new Asset();
+        asset.setAssetId(assetId);
+        asset.setAssetType(assetType);
+        asset.setTitle(title);
+        return asset;
+    }
+}

--- a/server/src/test/java/com/google/moviestvsentiments/assetSentiment/AssetSentimentControllerTest.java
+++ b/server/src/test/java/com/google/moviestvsentiments/assetSentiment/AssetSentimentControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.google.moviestvsentiments.AssetUtil;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -23,7 +24,7 @@ import java.util.Arrays;
 public class AssetSentimentControllerTest {
 
     private static final String ACCOUNT_NAME = "testAccount";
-    private static final Asset ASSET = createAsset("assetId", AssetType.MOVIE, "assetTitle");
+    private static final Asset ASSET = AssetUtil.createAsset("assetId", AssetType.MOVIE, "assetTitle");
     private static final UserSentiment SENTIMENT_1 = createUserSentiment("assetId", ACCOUNT_NAME, AssetType.MOVIE,
             SentimentType.THUMBS_UP);
     private static final UserSentiment SENTIMENT_2 = createUserSentiment("assetId2", ACCOUNT_NAME, AssetType.SHOW,
@@ -31,14 +32,6 @@ public class AssetSentimentControllerTest {
     private static final String SENTIMENT_LIST_JSON = "[ { \"assetId\": \"assetId\", \"assetType\": \"MOVIE\", " +
             "\"accountName\": \"testAccount\", \"sentimentType\": \"THUMBS_UP\"}, {\"assetId\": \"assetId2\", " +
             "\"assetType\": \"SHOW\", \"accountName\": \"testAccount\", \"sentimentType\": \"THUMBS_DOWN\"} ]";
-
-    private static Asset createAsset(String assetId, AssetType assetType, String title) {
-        Asset asset = new Asset();
-        asset.setAssetId(assetId);
-        asset.setAssetType(assetType);
-        asset.setTitle(title);
-        return asset;
-    }
 
     private static UserSentiment createUserSentiment(String assetId, String accountName, AssetType assetType,
                                                      SentimentType sentimentType) {
@@ -97,7 +90,7 @@ public class AssetSentimentControllerTest {
     public void getAssets_withUnspecified_returnsAssets() throws Exception {
         UserSentiment sentiment = createUserSentiment(ASSET.getAssetId(), ACCOUNT_NAME, ASSET.getAssetType(),
                 SentimentType.UNSPECIFIED);
-        Asset asset2 = createAsset("assetId2", AssetType.MOVIE, "assetTitle2");
+        Asset asset2 = AssetUtil.createAsset("assetId2", AssetType.MOVIE, "assetTitle2");
         when(assetSentimentRepository.getAssetsWithSentiment(AssetType.MOVIE, ACCOUNT_NAME, SentimentType.UNSPECIFIED))
                 .thenReturn(new ArrayList<>(Arrays.asList(new AssetSentiment(ASSET, sentiment))));
         when(assetSentimentRepository.getAssetsWithoutSentiment(AssetType.MOVIE, ACCOUNT_NAME))

--- a/server/src/test/java/com/google/moviestvsentiments/webscrape/AssetScrapeControllerTest.java
+++ b/server/src/test/java/com/google/moviestvsentiments/webscrape/AssetScrapeControllerTest.java
@@ -1,0 +1,79 @@
+package com.google.moviestvsentiments.webscrape;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.google.moviestvsentiments.AssetUtil;
+import com.google.moviestvsentiments.assetSentiment.Asset;
+import com.google.moviestvsentiments.assetSentiment.AssetSentimentRepository;
+import com.google.moviestvsentiments.assetSentiment.AssetType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AssetScrapeControllerTest {
+
+    private static final String OMDB_URL = "testurl";
+    private static final String API_KEY = "testApiKey";
+    private static final String TEST_URL = "/scrape?url=" + OMDB_URL + "&apiKey=" + API_KEY;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AssetSentimentRepository repository;
+
+    @MockBean
+    private AssetScraper scraper;
+
+    @Test
+    public void scrapeAssets_invokesDependenciesCorrectly() throws Exception {
+        List<String> assetIds = Arrays.asList("assetId1", "assetId2");
+        List<Asset> assets = Arrays.asList(AssetUtil.createAsset("assetId1", AssetType.MOVIE, "title1"),
+                AssetUtil.createAsset("assetId2", AssetType.SHOW, "title2"));
+        when(scraper.scrapeIds(OMDB_URL)).thenReturn(assetIds);
+        when(scraper.scrapeAssets(assetIds, API_KEY)).thenReturn(assets);
+
+        mockMvc.perform(get(TEST_URL));
+
+        verify(scraper, times(1)).scrapeIds(OMDB_URL);
+        verify(scraper, times(1)).scrapeAssets(assetIds, API_KEY);
+        verify(repository, times(1)).saveAll(assets);
+        verifyNoMoreInteractions(scraper, repository);
+    }
+
+    @Test
+    public void scrapeAssets_returnsOk() throws Exception {
+        List<String> assetIds = Arrays.asList("assetId1", "assetId2");
+        List<Asset> assets = Arrays.asList(AssetUtil.createAsset("assetId1", AssetType.MOVIE, "title1"),
+                AssetUtil.createAsset("assetId2", AssetType.SHOW, "title2"));
+        when(scraper.scrapeIds(OMDB_URL)).thenReturn(assetIds);
+        when(scraper.scrapeAssets(assetIds, API_KEY)).thenReturn(assets);
+
+        mockMvc.perform(get(TEST_URL)).andExpect(status().isOk());
+    }
+
+    @Test
+    public void scrapeAssets_failure_returnsServerError() throws Exception {
+        final String errorMessage = "Failed to scrape Asset ids";
+        when(scraper.scrapeIds(OMDB_URL)).thenThrow(new IOException(errorMessage));
+
+        mockMvc.perform(get(TEST_URL))
+                .andExpect(status().is5xxServerError())
+                .andExpect(jsonPath("$", equalTo(errorMessage)));
+    }
+}


### PR DESCRIPTION
Scrapes assets from OMDB by first scraping a list of asset ids from a provided IMDB url. Each asset id is then used to query the OMDB api. I'll be scraping the IMDB top 250 movies and top 250 tv shows, but other IMDB pages should be possible to scrape as well. Also changes the in-memory database to a file database, as I didn't want to query OMDB 500 times every time I restarted the server.