### PR TITLE
Add NetworkBoundResource class

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -113,6 +113,9 @@ dependencies {
     // Glide
     implementation "com.github.bumptech.glide:glide:4.11.0"
 
+    // Retrofit
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+
     // Testing
     androidTestImplementation "androidx.test:rules:1.1.0"
     androidTestImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"
@@ -124,4 +127,5 @@ dependencies {
     testImplementation "com.google.truth:truth:$rootProject.truthVersion"
     testImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"
     androidTestImplementation "pl.pragmatists:JUnitParams:1.1.1"
+    testImplementation "pl.pragmatists:JUnitParams:1.1.1"
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/ApiResponse.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/ApiResponse.java
@@ -1,0 +1,59 @@
+package com.google.moviestvsentiments.service.web;
+
+import java.io.IOException;
+import okhttp3.ResponseBody;
+import retrofit2.Response;
+
+/**
+ * A container that stores Response objects returned by Retrofit.
+ * @param <T> The type of the Response body.
+ */
+public class ApiResponse<T> {
+
+    private static final String DEFAULT_ERROR_MESSAGE = "Failed to make network request.";
+
+    private final Response<T> response;
+
+    /**
+     * Constructs an ApiResponse with a 500 status, a null body and the provided error message.
+     * This constructor should be used only when Retrofit fails to make a network request.
+     * @param error The error to take the error message from.
+     */
+    public ApiResponse(Throwable error) {
+        response = Response.error(500, ResponseBody.create(null, error.getMessage()));
+    }
+
+    /**
+     * Constructs an ApiResponse with the given response.
+     * @param response The response from the server.
+     */
+    public ApiResponse(Response<T> response) {
+        this.response = response;
+    }
+
+    /**
+     * Returns true if the ApiResponse has a 2xx status code.
+     */
+    public boolean isSuccessful() {
+        return response.isSuccessful();
+    }
+
+    /**
+     * Returns the body of the ApiResponse, or null if the response was unsuccessful.
+     */
+    public T getBody() {
+        return response.body();
+    }
+
+    /**
+     * Returns the error message from an unsuccessful response, or a default error if the error
+     * message cannot be extracted from the response body.
+     */
+    public String getError() {
+        try {
+            return response.errorBody().string();
+        } catch (IOException e) {
+            return DEFAULT_ERROR_MESSAGE;
+        }
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/NetworkBoundResource.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/NetworkBoundResource.java
@@ -1,0 +1,108 @@
+package com.google.moviestvsentiments.service.web;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MediatorLiveData;
+import java.util.Objects;
+
+/**
+ * A resource backed by both the local Room database and a remote server.
+ * @param <ServerType> The type of the resource on the server.
+ * @param <LocalType> The type of the resource locally.
+ */
+public abstract class NetworkBoundResource<ServerType, LocalType> {
+
+    private final MediatorLiveData<Resource<LocalType>> result = new MediatorLiveData<>();
+
+    /**
+     * Constructs a NetworkBoundResource that observes the local Room value for changes that
+     * may or may not trigger a network request.
+     */
+    NetworkBoundResource() {
+        result.setValue(Resource.loading(null));
+        LiveData<LocalType> dbSource = loadFromRoom();
+        result.addSource(dbSource, data -> {
+            result.removeSource(dbSource);
+            if (shouldFetch(data)) {
+                fetchFromNetwork(dbSource);
+            } else {
+                result.addSource(dbSource, newData -> setValue(Resource.success(newData)));
+            }
+        });
+    }
+
+    /**
+     * Returns a LiveData wrapper around the requested resource.
+     */
+    public LiveData<Resource<LocalType>> getResult() {
+        return result;
+    }
+
+    /**
+     * Returns the ServerType object contained within the provided ApiResponse. The default
+     * implementation of this method just returns the ApiResponse's body. Override this method if
+     * the body needs to be processed in some way to get the correct value.
+     * @param response The ApiResponse to process.
+     * @return The ServerType object contained within the ApiResponse.
+     */
+    protected ServerType processResponse(ApiResponse<ServerType> response) {
+        return response.getBody();
+    }
+
+    /**
+     * Saves the result of the network call in the Room database.
+     * @param item The return value from the network call.
+     */
+    protected abstract void saveCallResult(ServerType item);
+
+    /**
+     * Returns true if the resource should be updated by fetching a new copy from the network.
+     * @param data The local copy of the resource stored in the Room database.
+     * @return True if the resource should be fetched from the network.
+     */
+    protected abstract boolean shouldFetch(LocalType data);
+
+    /**
+     * Loads the requested resource from the Room database and returns a LiveData object wrapping
+     * the resource.
+     * @return A LiveData object wrapping the resource loaded from the Room database.
+     */
+    protected abstract LiveData<LocalType> loadFromRoom();
+
+    /**
+     * Performs the network call to the server and returns a LiveData object wrapping the response.
+     * @return A LiveData object wrapping the response from the server.
+     */
+    protected abstract LiveData<ApiResponse<ServerType>> performNetworkCall();
+
+    /**
+     * Sets the value of the LiveData result object if it has changed.
+     * @param newValue The new value of the result object.
+     */
+    private void setValue(Resource<LocalType> newValue) {
+        if (!Objects.equals(result.getValue(), newValue)) {
+            result.setValue(newValue);
+        }
+    }
+
+    /**
+     * Fetches the resource from the network and, if successful, saves the result in the Room
+     * database. The new result is then reloaded from the Room database. If unsuccessful, the Room
+     * database will continue to be the source for the result.
+     * @param dbSource The LiveData object returned by the Room database.
+     */
+    private void fetchFromNetwork(final LiveData<LocalType> dbSource) {
+        LiveData<ApiResponse<ServerType>> apiResponse = performNetworkCall();
+        result.addSource(dbSource, newData -> setValue(Resource.loading(newData)));
+        result.addSource(apiResponse, response -> {
+            result.removeSource(apiResponse);
+            result.removeSource(dbSource);
+            if (response.isSuccessful()) {
+                saveCallResult(processResponse(response));
+                result.addSource(dbSource, newData -> setValue(Resource.success(newData)));
+            } else {
+                result.addSource(dbSource,
+                        newData -> setValue(Resource.error(newData, response.getError())));
+            }
+        });
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/Resource.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/Resource.java
@@ -1,0 +1,99 @@
+package com.google.moviestvsentiments.service.web;
+
+/**
+ * A container for a value, its loading status and an error message.
+ * @param <T> The type of value stored.
+ */
+public class Resource<T> {
+
+    /**
+     * Represents the loading status of a Resource.
+     */
+    public enum Status {
+        LOADING,
+        SUCCESS,
+        ERROR
+    }
+
+    /**
+     * Creates a new Resource with the provided value and a status of LOADING.
+     * @param value The value to store in the Resource.
+     * @param <T> The type of the value.
+     * @return A new Resource with the provided value and a status of LOADING.
+     */
+    public static <T> Resource<T> loading(T value) {
+        return new Resource<>(Status.LOADING, value, null);
+    }
+
+    /**
+     * Creates a new Resource with the provided value and a status of SUCCESS.
+     * @param value The value to store in the Resource.
+     * @param <T> The type of the value.
+     * @return A new Resource with the provided value and a status of SUCCESS.
+     */
+    public static <T> Resource<T> success(T value) {
+        return new Resource<>(Status.SUCCESS, value, null);
+    }
+
+    /**
+     * Creates a new Resource with the provided value, error message and a status of ERROR.
+     * @param value The value to store in the Resource.
+     * @param error The error message to store in the Resource.
+     * @param <T> The type of the value.
+     * @return A new Resource with the provided value, error message and a status of ERROR.
+     */
+    public static <T> Resource<T> error(T value, String error) {
+        return new Resource<>(Status.ERROR, value, error);
+    }
+
+    private final Status status;
+    private final T value;
+    private final String error;
+
+    private Resource(Status status, T value, String error) {
+        this.status = status;
+        this.value = value;
+        this.error = error;
+    }
+
+    /**
+     * Returns the loading status of the Resource.
+     */
+    public Status getStatus() {
+        return status;
+    }
+
+    /**
+     * Returns the value of the Resource.
+     */
+    public T getValue() {
+        return value;
+    }
+
+    /**
+     * Returns the error message of the Resource.
+     */
+    public String getError() {
+        return error;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Resource<?> resource = (Resource<?>) o;
+
+        if (status != resource.status) return false;
+        if (value != null ? !value.equals(resource.value) : resource.value != null) return false;
+        return error != null ? error.equals(resource.error) : resource.error == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = status.hashCode();
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result = 31 * result + (error != null ? error.hashCode() : 0);
+        return result;
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/Resource.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/Resource.java
@@ -1,10 +1,14 @@
 package com.google.moviestvsentiments.service.web;
 
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+
 /**
  * A container for a value, its loading status and an error message.
  * @param <T> The type of value stored.
  */
-public class Resource<T> {
+@AutoValue
+public abstract class Resource<T> {
 
     /**
      * Represents the loading status of a Resource.
@@ -22,7 +26,7 @@ public class Resource<T> {
      * @return A new Resource with the provided value and a status of LOADING.
      */
     public static <T> Resource<T> loading(T value) {
-        return new Resource<>(Status.LOADING, value, null);
+        return new AutoValue_Resource<>(Status.LOADING, value, null);
     }
 
     /**
@@ -32,7 +36,7 @@ public class Resource<T> {
      * @return A new Resource with the provided value and a status of SUCCESS.
      */
     public static <T> Resource<T> success(T value) {
-        return new Resource<>(Status.SUCCESS, value, null);
+        return new AutoValue_Resource<>(Status.SUCCESS, value, null);
     }
 
     /**
@@ -43,57 +47,23 @@ public class Resource<T> {
      * @return A new Resource with the provided value, error message and a status of ERROR.
      */
     public static <T> Resource<T> error(T value, String error) {
-        return new Resource<>(Status.ERROR, value, error);
-    }
-
-    private final Status status;
-    private final T value;
-    private final String error;
-
-    private Resource(Status status, T value, String error) {
-        this.status = status;
-        this.value = value;
-        this.error = error;
+        return new AutoValue_Resource<>(Status.ERROR, value, error);
     }
 
     /**
      * Returns the loading status of the Resource.
      */
-    public Status getStatus() {
-        return status;
-    }
+    public abstract Status getStatus();
 
     /**
      * Returns the value of the Resource.
      */
-    public T getValue() {
-        return value;
-    }
+    @Nullable
+    public abstract T getValue();
 
     /**
      * Returns the error message of the Resource.
      */
-    public String getError() {
-        return error;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Resource<?> resource = (Resource<?>) o;
-
-        if (status != resource.status) return false;
-        if (value != null ? !value.equals(resource.value) : resource.value != null) return false;
-        return error != null ? error.equals(resource.error) : resource.error == null;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = status.hashCode();
-        result = 31 * result + (value != null ? value.hashCode() : 0);
-        result = 31 * result + (error != null ? error.hashCode() : 0);
-        return result;
-    }
+    @Nullable
+    public abstract String getError();
 }

--- a/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/web/NetworkBoundResourceTest.java
+++ b/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/web/NetworkBoundResourceTest.java
@@ -31,8 +31,8 @@ public class NetworkBoundResourceTest {
 
     @Test
     @Parameters(method = "invokesCorrectMethodsParameters")
-    public void shouldFetchResult_invokesCorrectMethods(boolean shouldFetch,
-                                                        boolean[] expectedInvocations) {
+    public void networkBoundResource_invokesCorrectMethods(boolean shouldFetchReturnValue,
+                                                           boolean[] expectedInvocations) {
         final boolean[] invocations = {false, false, false, false};
         NetworkBoundResource resource = new NetworkBoundResource<String, String>() {
             @Override protected void saveCallResult(String item) {
@@ -41,7 +41,7 @@ public class NetworkBoundResourceTest {
 
             @Override protected boolean shouldFetch(String data) {
                 invocations[1] = true;
-                return shouldFetch;
+                return shouldFetchReturnValue;
             }
 
             @Override protected LiveData<String> loadFromRoom() {
@@ -62,13 +62,15 @@ public class NetworkBoundResourceTest {
 
     @Test
     public void networkBoundResource_passesCorrectParameters() {
+        final String[] shouldFetchParameter = new String[1];
+        final String[] saveCallResultParameter = new String[1];
         NetworkBoundResource resource = new NetworkBoundResource<String, String>() {
             @Override protected void saveCallResult(String item) {
-                assertThat(item).isEqualTo(SERVER_VALUE);
+                saveCallResultParameter[0] = item;
             }
 
             @Override protected boolean shouldFetch(String data) {
-                assertThat(data).isEqualTo(LOCAL_VALUE);
+                shouldFetchParameter[0] = data;
                 return true;
             }
 
@@ -82,6 +84,9 @@ public class NetworkBoundResourceTest {
         };
 
         resource.getResult().observeForever(data -> {});
+
+        assertThat(saveCallResultParameter[0]).isEqualTo(SERVER_VALUE);
+        assertThat(shouldFetchParameter[0]).isEqualTo(LOCAL_VALUE);
     }
 
     private Object[] returnsCorrectValueParameters() {

--- a/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/web/NetworkBoundResourceTest.java
+++ b/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/web/NetworkBoundResourceTest.java
@@ -1,0 +1,170 @@
+package com.google.moviestvsentiments.service.web;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import com.google.moviestvsentiments.util.LiveDataTestUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import retrofit2.Response;
+
+@RunWith(JUnitParamsRunner.class)
+public class NetworkBoundResourceTest {
+
+    private static final String LOCAL_VALUE = "Local Value";
+    private static final String SERVER_VALUE = "Server Value";
+
+    @Rule
+    public InstantTaskExecutorRule instantExecutorRule = new InstantTaskExecutorRule();
+
+    private Object[] invokesCorrectMethodsParameters() {
+        return new Object[] {
+            new Object[] {false, new boolean[] {false, true, true, false} },
+            new Object[] {true, new boolean[] {true, true, true, true} }
+        };
+    }
+
+    @Test
+    @Parameters(method = "invokesCorrectMethodsParameters")
+    public void shouldFetchResult_invokesCorrectMethods(boolean shouldFetch,
+                                                        boolean[] expectedInvocations) {
+        final boolean[] invocations = {false, false, false, false};
+        NetworkBoundResource resource = new NetworkBoundResource<String, String>() {
+            @Override protected void saveCallResult(String item) {
+                invocations[0] = true;
+            }
+
+            @Override protected boolean shouldFetch(String data) {
+                invocations[1] = true;
+                return shouldFetch;
+            }
+
+            @Override protected LiveData<String> loadFromRoom() {
+                invocations[2] = true;
+                return new MutableLiveData<>("testValue");
+            }
+
+            @Override protected LiveData<ApiResponse<String>> performNetworkCall() {
+                invocations[3] = true;
+                return new MutableLiveData<>(new ApiResponse(Response.success("Server value")));
+            }
+        };
+
+        resource.getResult().observeForever(data -> {});
+
+        assertThat(invocations).isEqualTo(expectedInvocations);
+    }
+
+    @Test
+    public void networkBoundResource_passesCorrectParameters() {
+        NetworkBoundResource resource = new NetworkBoundResource<String, String>() {
+            @Override protected void saveCallResult(String item) {
+                assertThat(item).isEqualTo(SERVER_VALUE);
+            }
+
+            @Override protected boolean shouldFetch(String data) {
+                assertThat(data).isEqualTo(LOCAL_VALUE);
+                return true;
+            }
+
+            @Override protected LiveData<String> loadFromRoom() {
+                return new MutableLiveData<>(LOCAL_VALUE);
+            }
+
+            @Override protected LiveData<ApiResponse<String>> performNetworkCall() {
+                return new MutableLiveData<>(new ApiResponse(Response.success(SERVER_VALUE)));
+            }
+        };
+
+        resource.getResult().observeForever(data -> {});
+    }
+
+    private Object[] returnsCorrectValueParameters() {
+        return new Object[] {
+            new Object[] { false, null, Resource.success(LOCAL_VALUE) },
+            new Object[] { true, new ApiResponse(new RuntimeException("Error message")),
+                    Resource.error(LOCAL_VALUE, "Error message") },
+            new Object[] { true, new ApiResponse(Response.success(SERVER_VALUE)),
+                    Resource.success(SERVER_VALUE) }
+        };
+    }
+
+    @Test
+    @Parameters(method = "returnsCorrectValueParameters")
+    public void networkBoundResource_returnsCorrectValue(boolean shouldFetch,
+                                     ApiResponse<String> networkResponse, Resource expectedResult) {
+        MutableLiveData<String> roomValue = new MutableLiveData<>(LOCAL_VALUE);
+        NetworkBoundResource resource = new NetworkBoundResource<String, String>() {
+            @Override protected void saveCallResult(String item) {
+                roomValue.setValue(item);
+            }
+
+            @Override protected boolean shouldFetch(String data) {
+                return shouldFetch;
+            }
+
+            @Override protected LiveData<String> loadFromRoom() {
+                return roomValue;
+            }
+
+            @Override protected LiveData<ApiResponse<String>> performNetworkCall() {
+                return new MutableLiveData<>(networkResponse);
+            }
+        };
+
+        Resource<String> result = (Resource<String>)LiveDataTestUtil.getValue(resource.getResult());
+
+        assertThat(result).isEqualTo(expectedResult);
+    }
+
+    @Test
+    public void networkBoundResource_noRoomResult_returnsLoadingResource() {
+        NetworkBoundResource resource = new NetworkBoundResource<String, String>() {
+            @Override protected void saveCallResult(String item) {}
+
+            @Override protected boolean shouldFetch(String data) {
+                return false;
+            }
+
+            @Override protected LiveData<String> loadFromRoom() {
+                return new MutableLiveData<>();
+            }
+
+            @Override protected LiveData<ApiResponse<String>> performNetworkCall() {
+                return null;
+            }
+        };
+
+        Resource<String> result = (Resource<String>)LiveDataTestUtil.getValue(resource.getResult());
+
+        assertThat(result).isEqualTo(Resource.loading(null));
+    }
+
+    @Test
+    public void networkBoundResource_noServerResult_returnsLoadingResource() {
+        NetworkBoundResource resource = new NetworkBoundResource<String, String>() {
+            @Override protected void saveCallResult(String item) {}
+
+            @Override protected boolean shouldFetch(String data) {
+                return true;
+            }
+
+            @Override protected LiveData<String> loadFromRoom() {
+                return new MutableLiveData<>(LOCAL_VALUE);
+            }
+
+            @Override protected LiveData<ApiResponse<String>> performNetworkCall() {
+                return new MutableLiveData<>();
+            }
+        };
+
+        Resource<String> result = (Resource<String>)LiveDataTestUtil.getValue(resource.getResult());
+
+        assertThat(result).isEqualTo(Resource.loading(LOCAL_VALUE));
+    }
+}


### PR DESCRIPTION
Adds the NetworkBoundResource, Resource and ApiResponse classes in order to support fetching from the server and caching in Room. These classes are based off the GithubBrowser architecture component sample project. That project's NetworkBoundResource can be found [here](https://github.com/android/architecture-components-samples/blob/b1a194c1ae267258cd002e2e1c102df7180be473/GithubBrowserSample/app/src/main/java/com/android/example/github/repository/NetworkBoundResource.java). 