### PR TITLE
Add account endpoints to WebService, LiveData adapters

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -113,8 +113,11 @@ dependencies {
     // Glide
     implementation "com.github.bumptech.glide:glide:4.11.0"
 
-    // Retrofit
+    // Retrofit and Jackson
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-jackson:2.9.0'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.1'
 
     // Testing
     androidTestImplementation "androidx.test:rules:1.1.0"

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/di/WebModule.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/di/WebModule.java
@@ -1,0 +1,37 @@
+package com.google.moviestvsentiments.di;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.moviestvsentiments.service.web.LiveDataCallAdapterFactory;
+import com.google.moviestvsentiments.service.web.WebService;
+import javax.inject.Singleton;
+import dagger.Module;
+import dagger.Provides;
+import dagger.hilt.InstallIn;
+import dagger.hilt.android.components.ApplicationComponent;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+
+@InstallIn(ApplicationComponent.class)
+@Module
+public class WebModule {
+
+    private static final String API_BASE_URL = "http://10.0.2.2:8080";
+
+    @Provides
+    @Singleton
+    public WebService provideWebService() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        Retrofit retrofit = new Retrofit.Builder()
+                .baseUrl(API_BASE_URL)
+                .addConverterFactory(JacksonConverterFactory.create(mapper))
+                .addCallAdapterFactory(new LiveDataCallAdapterFactory())
+                .build();
+        return retrofit.create(WebService.class);
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/LiveDataCallAdapter.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/LiveDataCallAdapter.java
@@ -1,0 +1,75 @@
+package com.google.moviestvsentiments.service.web;
+
+import androidx.lifecycle.LiveData;
+import java.lang.reflect.Type;
+import java.util.concurrent.atomic.AtomicBoolean;
+import retrofit2.Call;
+import retrofit2.CallAdapter;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+/**
+ * A Retrofit adapter that converts a Call object into an ApiResponse wrapped by a LiveData object.
+ * @param <T> The type of the Call and ApiResponse objects.
+ */
+public class LiveDataCallAdapter<T> implements CallAdapter<T, LiveData<ApiResponse<T>>> {
+
+    /**
+     * A LiveData class that posts ApiResponse values when a Retrofit call completes.
+     * @param <R> The type of the Call and ApiResponse objects.
+     */
+    private static class LiveDataApiResponse<R> extends LiveData<ApiResponse<R>> {
+
+        private AtomicBoolean started = new AtomicBoolean(false);
+        private Call<R> call;
+
+        private LiveDataApiResponse(Call<R> call) {
+            this.call = call;
+        }
+
+        @Override
+        protected void onActive() {
+            super.onActive();
+            if (started.compareAndSet(false, true)) {
+                call.enqueue(new Callback<R>() {
+                    @Override
+                    public void onResponse(Call<R> call, Response<R> response) {
+                        postValue(new ApiResponse<>(response));
+                    }
+
+                    @Override
+                    public void onFailure(Call<R> call, Throwable throwable) {
+                        postValue(new ApiResponse<R>(throwable));
+                    }
+                });
+            }
+        }
+    }
+
+    private final Type responseType;
+
+    private LiveDataCallAdapter(Type responseType) {
+        this.responseType = responseType;
+    }
+
+    /**
+     * Creates a new LiveDataCallAdapater with the given response type.
+     * @param responseType The value type that the adapter uses when converting the HTTP response
+     *                     body to a JSON object.
+     * @param <T> The type of the Call and ApiResponse objects that will be used with the adapter.
+     * @return A new LiveDataCallAdapter with the given response type.
+     */
+    public static <T> LiveDataCallAdapter<T> create(Type responseType) {
+        return new LiveDataCallAdapter<>(responseType);
+    }
+
+    @Override
+    public Type responseType() {
+        return responseType;
+    }
+
+    @Override
+    public LiveData<ApiResponse<T>> adapt(Call<T> call) {
+        return new LiveDataApiResponse<>(call);
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/LiveDataCallAdapterFactory.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/LiveDataCallAdapterFactory.java
@@ -1,0 +1,36 @@
+package com.google.moviestvsentiments.service.web;
+
+import androidx.lifecycle.LiveData;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import javax.annotation.Nullable;
+import retrofit2.CallAdapter;
+import retrofit2.Retrofit;
+
+/**
+ * A Retrofit CallAdapter factory that creates LiveDataCallAdapters.
+ */
+public class LiveDataCallAdapterFactory extends CallAdapter.Factory {
+
+    @Nullable
+    @Override
+    public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+        if (getRawType(returnType) != LiveData.class) {
+            return null;
+        }
+
+        Type observableType = getParameterUpperBound(0, (ParameterizedType) returnType);
+        Class<?> rawObservableType = getRawType(observableType);
+        if (rawObservableType != ApiResponse.class) {
+            throw new IllegalArgumentException("Type must be an ApiResponse");
+        }
+
+        if (! (observableType instanceof ParameterizedType)) {
+            throw new IllegalArgumentException("Resource must be parameterized");
+        }
+
+        Type bodyType = getParameterUpperBound(0, (ParameterizedType) observableType);
+        return LiveDataCallAdapter.create(bodyType);
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/WebService.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/WebService.java
@@ -1,0 +1,17 @@
+package com.google.moviestvsentiments.service.web;
+
+import androidx.lifecycle.LiveData;
+import com.google.moviestvsentiments.model.Account;
+import java.util.List;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+
+public interface WebService {
+
+    @GET("accounts")
+    LiveData<ApiResponse<List<Account>>> getAlphabetizedAccounts();
+
+    @POST("accounts")
+    LiveData<ApiResponse<Account>> addAccounts(@Body List<Account> accounts);
+}


### PR DESCRIPTION
Adds some more configuration/preparation for connecting the app to the server. This pull request adds a basic definition of the WebService (which currently contains just the two account endpoints), an adapter to convert the WebService's response into LiveData, and a Hilt module so that Hilt can inject the WebService into the repositories. The next pull request will have the app use the GET /accounts endpoint when querying for the account names. 