### PR TITLE
Fetch accounts from server

### DIFF
--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/account/AccountDaoTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/account/AccountDaoTest.java
@@ -60,7 +60,7 @@ public class AccountDaoTest {
         accountDao.addAccount("John Doe");
         List<Account> accounts = LiveDataTestUtil.getValue(accountDao.getAlphabetizedAccounts());
 
-        assertThat(accounts.get(0).timestamp).isGreaterThan(0);
+        assertThat(accounts.get(0).timestamp.getEpochSecond()).isGreaterThan(0);
     }
 
     @Test

--- a/MoviesTVSentiments/app/src/main/AndroidManifest.xml
+++ b/MoviesTVSentiments/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/di/WebModule.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/di/WebModule.java
@@ -10,17 +10,21 @@ import dagger.Provides;
 import dagger.hilt.InstallIn;
 import dagger.hilt.android.components.ApplicationComponent;
 import retrofit2.Retrofit;
-import retrofit2.converter.gson.GsonConverterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
-
+/**
+ * A Hilt module that provides web-related dependencies.
+ */
 @InstallIn(ApplicationComponent.class)
 @Module
 public class WebModule {
 
     private static final String API_BASE_URL = "http://10.0.2.2:8080";
 
+    /**
+     * Returns the singleton WebService object.
+     */
     @Provides
     @Singleton
     public WebService provideWebService() {

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/Account.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/Account.java
@@ -4,6 +4,7 @@ import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.PrimaryKey;
+import java.time.Instant;
 
 /**
  * A record in the accounts database table.
@@ -18,7 +19,7 @@ public class Account {
 
     @NonNull
     @ColumnInfo(name = "timestamp", defaultValue = "CURRENT_TIMESTAMP")
-    public long timestamp;
+    public Instant timestamp;
 
     @NonNull
     @ColumnInfo(name = "is_current", defaultValue = "0")

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountDao.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountDao.java
@@ -2,6 +2,8 @@ package com.google.moviestvsentiments.service.account;
 
 import androidx.lifecycle.LiveData;
 import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
 import com.google.moviestvsentiments.model.Account;
 import java.util.List;
@@ -19,6 +21,14 @@ public abstract class AccountDao {
      */
     @Query("INSERT OR IGNORE INTO accounts_table (account_name) VALUES (:name)")
     public abstract void addAccount(String name);
+
+    /**
+     * Adds all of the given accounts into the accounts table. If any already exist, they are
+     * replaced.
+     * @param accounts The accounts to insert into the table.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    public abstract void addAccounts(List<Account> accounts);
 
     /**
      * Returns a LiveData list of all accounts in alphabetical order.

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountRepository.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountRepository.java
@@ -2,6 +2,10 @@ package com.google.moviestvsentiments.service.account;
 
 import androidx.lifecycle.LiveData;
 import com.google.moviestvsentiments.model.Account;
+import com.google.moviestvsentiments.service.web.ApiResponse;
+import com.google.moviestvsentiments.service.web.NetworkBoundResource;
+import com.google.moviestvsentiments.service.web.Resource;
+import com.google.moviestvsentiments.service.web.WebService;
 import java.util.List;
 import java.util.concurrent.Executor;
 import javax.inject.Inject;
@@ -13,21 +17,25 @@ public class AccountRepository {
 
     private final AccountDao accountDao;
     private final Executor executor;
+    private final WebService webService;
 
     @Inject
-    AccountRepository(AccountDao accountDao, Executor executor) {
+    AccountRepository(AccountDao accountDao, Executor executor, WebService webService) {
         this.accountDao = accountDao;
         this.executor = executor;
+        this.webService = webService;
     }
 
     /**
      * Returns a new AccountRepository object.
      * @param accountDao The Dao object to use when accessing the local database.
      * @param executor The Executor to use when writing to the database.
+     * @param webService The WebService to use when fetching from the server.
      * @return A new AccountRepository object.
      */
-    public static AccountRepository create(AccountDao accountDao, Executor executor) {
-        return new AccountRepository(accountDao, executor);
+    public static AccountRepository create(AccountDao accountDao, Executor executor,
+                                           WebService webService) {
+        return new AccountRepository(accountDao, executor, webService);
     }
 
     /**
@@ -42,22 +50,47 @@ public class AccountRepository {
     }
 
     /**
-     * Returns a LiveData list of all accounts sorted by name in alphabetical order.
+     * Returns a LiveData list of all accounts sorted by name in alphabetical order. The account
+     * list is pulled from the server and cached locally in the Room database.
      */
-    LiveData<List<Account>> getAlphabetizedAccounts() {
-        return accountDao.getAlphabetizedAccounts();
+    LiveData<Resource<List<Account>>> getAlphabetizedAccounts() {
+        return new NetworkBoundResource<List<Account>, List<Account>>() {
+            @Override
+            protected void saveCallResult(List<Account> accounts) {
+                executor.execute(() -> {
+                    accountDao.addAccounts(accounts);
+                });
+            }
+
+            @Override
+            protected boolean shouldFetch(List<Account> data) {
+                return true;
+            }
+
+            @Override
+            protected LiveData<List<Account>> loadFromRoom() {
+                return accountDao.getAlphabetizedAccounts();
+            }
+
+            @Override
+            protected LiveData<ApiResponse<List<Account>>> performNetworkCall() {
+                return webService.getAlphabetizedAccounts();
+            }
+        }.getResult();
     }
 
     /**
      * Returns a LiveData object containing the currently signed-in account or null if all accounts
-     * are signed out.
+     * are signed out. This method does not make a request to the server, as the server does not
+     * have the notion of current accounts.
      */
     LiveData<Account> getCurrentAccount() {
         return accountDao.getCurrentAccount();
     }
 
     /**
-     * Updates the given account record's is_current value.
+     * Updates the given account record's is_current value. This method does not make a request to
+     * the server, as the server does not have the notion of current accounts.
      * @param name The name of the account to update.
      * @param isCurrent The value to set is_current to.
      */

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountViewModel.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountViewModel.java
@@ -3,6 +3,7 @@ package com.google.moviestvsentiments.service.account;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModel;
 import com.google.moviestvsentiments.model.Account;
+import com.google.moviestvsentiments.service.web.Resource;
 import java.util.List;
 import javax.inject.Inject;
 
@@ -39,7 +40,7 @@ public class AccountViewModel extends ViewModel {
     /**
      * Returns a LiveData list of all accounts sorted by name in alphabetical order.
      */
-    public LiveData<List<Account>> getAlphabetizedAccounts() {
+    public LiveData<Resource<List<Account>>> getAlphabetizedAccounts() {
         return repository.getAlphabetizedAccounts();
     }
 

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/database/SentimentsDatabase.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/database/SentimentsDatabase.java
@@ -16,7 +16,7 @@ import com.google.moviestvsentiments.service.assetSentiment.AssetSentimentDao;
  */
 @Database(entities = {Account.class, Asset.class, UserSentiment.class}, version = 1,
         exportSchema = false)
-@TypeConverters({AssetType.class, SentimentType.class})
+@TypeConverters({AssetType.class, SentimentType.class, SentimentsTypeConverters.class})
 public abstract class SentimentsDatabase extends RoomDatabase {
 
     /**

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/database/SentimentsTypeConverters.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/database/SentimentsTypeConverters.java
@@ -1,0 +1,31 @@
+package com.google.moviestvsentiments.service.database;
+
+import androidx.room.TypeConverter;
+import java.time.Instant;
+
+/**
+ * Contains methods for converting between types when accessing data in the Room database.
+ */
+public class SentimentsTypeConverters {
+
+    /**
+     * Converts a long timestamp into an Instant timestamp. The long timestamp should be a number
+     * of epoch seconds.
+     * @param timestamp The long to convert to Instant.
+     * @return An Instant with the same timestamp.
+     */
+    @TypeConverter
+    public static Instant longToInstant(long timestamp) {
+        return Instant.ofEpochSecond(timestamp);
+    }
+
+    /**
+     * Converts an Instant timestamp into a long timestamp.
+     * @param timestamp The Instant to convert to long.
+     * @return The number of seconds that have passed since the epoch.
+     */
+    @TypeConverter
+    public static long instantToLong(Instant timestamp) {
+        return timestamp.getEpochSecond();
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/NetworkBoundResource.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/NetworkBoundResource.java
@@ -17,7 +17,7 @@ public abstract class NetworkBoundResource<ServerType, LocalType> {
      * Constructs a NetworkBoundResource that observes the local Room value for changes that
      * may or may not trigger a network request.
      */
-    NetworkBoundResource() {
+    public NetworkBoundResource() {
         result.setValue(Resource.loading(null));
         LiveData<LocalType> dbSource = loadFromRoom();
         result.addSource(dbSource, data -> {

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/WebService.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/WebService.java
@@ -7,11 +7,23 @@ import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
 
+/**
+ * A Retrofit service that provides access to the remote server.
+ */
 public interface WebService {
 
+    /**
+     * Returns a LiveData list of Accounts sorted in ascending alphabetical order.
+     */
     @GET("accounts")
     LiveData<ApiResponse<List<Account>>> getAlphabetizedAccounts();
 
+    /**
+     * Adds the given list of Accounts to the remote server's database and returns the list of
+     * successfully added Accounts.
+     * @param accounts The list of Accounts to add.
+     * @return The list of successfully added Accounts.
+     */
     @POST("accounts")
     LiveData<ApiResponse<Account>> addAccounts(@Body List<Account> accounts);
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
@@ -1,18 +1,15 @@
 package com.google.moviestvsentiments.usecase.signin;
 
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.lifecycle.Observer;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import android.content.Intent;
 import android.os.Bundle;
 import com.google.moviestvsentiments.R;
-import com.google.moviestvsentiments.model.Account;
 import com.google.moviestvsentiments.service.account.AccountViewModel;
 import com.google.moviestvsentiments.usecase.addAccount.AddAccountActivity;
 import com.google.moviestvsentiments.usecase.navigation.SentimentsNavigationActivity;
 import dagger.hilt.android.AndroidEntryPoint;
-import java.util.List;
 import javax.inject.Inject;
 
 /**
@@ -49,8 +46,10 @@ public class SigninActivity extends AppCompatActivity implements AccountListAdap
         accountList.setAdapter(adapter);
         accountList.setLayoutManager(new LinearLayoutManager(this));
 
-        viewModel.getAlphabetizedAccounts().observe(this, accounts -> {
-            adapter.setAccounts(accounts);
+        viewModel.getAlphabetizedAccounts().observe(this, resource -> {
+            if (resource.getValue() != null) {
+                adapter.setAccounts(resource.getValue());
+            }
         });
     }
 

--- a/MoviesTVSentiments/app/src/main/res/xml/network_security_config.xml
+++ b/MoviesTVSentiments/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>

--- a/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/account/AccountViewModelTest.java
+++ b/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/account/AccountViewModelTest.java
@@ -8,21 +8,23 @@ import static org.mockito.Mockito.when;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.lifecycle.MutableLiveData;
 import com.google.moviestvsentiments.model.Account;
+import com.google.moviestvsentiments.service.web.Resource;
 import com.google.moviestvsentiments.util.LiveDataTestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
 @RunWith(JUnit4.class)
 public class AccountViewModelTest {
 
-    private static final Account ACCOUNT = createAccount("Account Name", 13, true);
+    private static final Account ACCOUNT = createAccount("Account Name", Instant.ofEpochSecond(13), true);
 
-    private static Account createAccount(String accountName, long timestamp, boolean isCurrent) {
+    private static Account createAccount(String accountName, Instant timestamp, boolean isCurrent) {
         Account account = new Account();
         account.name = accountName;
         account.timestamp = timestamp;
@@ -51,13 +53,13 @@ public class AccountViewModelTest {
 
     @Test
     public void getAlphabetizedAccounts_returnsAccounts() {
-        MutableLiveData<List<Account>> accountsData = new MutableLiveData<>();
-        accountsData.setValue(Arrays.asList(ACCOUNT));
+        MutableLiveData<Resource<List<Account>>> accountsData = new MutableLiveData<>();
+        accountsData.setValue(Resource.success(Arrays.asList(ACCOUNT)));
         when(repository.getAlphabetizedAccounts()).thenReturn(accountsData);
 
-        List<Account> results = LiveDataTestUtil.getValue(viewModel.getAlphabetizedAccounts());
+        Resource<List<Account>> resource = LiveDataTestUtil.getValue(viewModel.getAlphabetizedAccounts());
 
-        assertThat(results).containsExactly(ACCOUNT);
+        assertThat(resource.getValue()).containsExactly(ACCOUNT);
     }
 
     @Test

--- a/server/src/main/java/com/google/moviestvsentiments/account/Account.java
+++ b/server/src/main/java/com/google/moviestvsentiments/account/Account.java
@@ -12,40 +12,40 @@ import java.util.Objects;
 public class Account {
     
     @Id
-    private String accountName;
+    private String name;
     private Instant timestamp;
 
     // The default constructor is required by the Spring JPA.
     protected Account() {}
 
-    private Account(String accountName, Instant timestamp) {
-        this.accountName = accountName;
+    private Account(String name, Instant timestamp) {
+        this.name = name;
         this.timestamp = timestamp;
     }
 
     /**
      * Creates a new Account with the given name and timestamp.
-     * @param accountName The name for the new account.
+     * @param name The name for the new account.
      * @param timestamp The timestamp for the new account.
      * @return A new Account with the given name and timestamp.
      */
-    public static Account create(String accountName, Instant timestamp) {
-        return new Account(accountName, timestamp);
+    public static Account create(String name, Instant timestamp) {
+        return new Account(name, timestamp);
     }
 
     /**
      * Returns the account name.
      */
-    public String getAccountName() {
-        return accountName;
+    public String getName() {
+        return name;
     }
 
     /**
      * Sets the account name.
-     * @param accountName The new name for the account.
+     * @param name The new name for the account.
      */
-    public void setAccountName(String accountName) {
-        this.accountName = accountName;
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**
@@ -69,11 +69,11 @@ public class Account {
         if (o == null || getClass() != o.getClass()) return false;
         Account account = (Account) o;
         return timestamp.equals(account.timestamp) &&
-                accountName.equals(account.accountName);
+                name.equals(account.name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(accountName, timestamp);
+        return Objects.hash(name, timestamp);
     }
 }

--- a/server/src/main/java/com/google/moviestvsentiments/account/AccountController.java
+++ b/server/src/main/java/com/google/moviestvsentiments/account/AccountController.java
@@ -27,7 +27,7 @@ public class AccountController {
      */
     @GetMapping("/accounts")
     public List<Account> getAccounts() {
-        Iterable<Account> accounts = repository.findAll(Sort.by("accountName"));
+        Iterable<Account> accounts = repository.findAll(Sort.by("name"));
         return StreamSupport.stream(accounts.spliterator(), false).collect(Collectors.toList());
     }
 

--- a/server/src/test/java/com/google/moviestvsentiments/account/AccountControllerTest.java
+++ b/server/src/test/java/com/google/moviestvsentiments/account/AccountControllerTest.java
@@ -27,8 +27,8 @@ public class AccountControllerTest {
 
     private static final Account ACCOUNT_1 = Account.create("Test Name 1", Instant.ofEpochSecond(0));
     private static final Account ACCOUNT_2 = Account.create("Test Name 2", Instant.ofEpochSecond(1));
-    private static final String ACCOUNT_LIST_JSON = "[ { \"accountName\": \"Test Name 1\", \"timestamp\": 0 }, " +
-            "{\"accountName\": \"Test Name 2\", \"timestamp\": 1} ]";
+    private static final String ACCOUNT_LIST_JSON = "[ { \"name\": \"Test Name 1\", \"timestamp\": 0 }, " +
+            "{\"name\": \"Test Name 2\", \"timestamp\": 1} ]";
 
     @Autowired
     private MockMvc mockMvc;
@@ -43,9 +43,9 @@ public class AccountControllerTest {
         mockMvc.perform(get("/accounts"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(2)))
-                .andExpect(jsonPath("$[0].accountName", equalTo(ACCOUNT_1.getAccountName())))
+                .andExpect(jsonPath("$[0].name", equalTo(ACCOUNT_1.getName())))
                 .andExpect(jsonPath("$[0].timestamp", equalTo(ACCOUNT_1.getTimestamp().toString())))
-                .andExpect(jsonPath("$[1].accountName", equalTo(ACCOUNT_2.getAccountName())))
+                .andExpect(jsonPath("$[1].name", equalTo(ACCOUNT_2.getName())))
                 .andExpect(jsonPath("$[1].timestamp", equalTo(ACCOUNT_2.getTimestamp().toString())));
     }
 
@@ -67,9 +67,9 @@ public class AccountControllerTest {
         when(mockRepository.saveAll(any(Iterable.class))).thenReturn(Arrays.asList(ACCOUNT_1, ACCOUNT_2));
 
         mockMvc.perform(post("/accounts").contentType(MediaType.APPLICATION_JSON).content(ACCOUNT_LIST_JSON))
-                .andExpect(jsonPath("$.accounts[0].accountName", equalTo(ACCOUNT_1.getAccountName())))
+                .andExpect(jsonPath("$.accounts[0].name", equalTo(ACCOUNT_1.getName())))
                 .andExpect(jsonPath("$.accounts[0].timestamp", equalTo(ACCOUNT_1.getTimestamp().toString())))
-                .andExpect(jsonPath("$.accounts[1].accountName", equalTo(ACCOUNT_2.getAccountName())))
+                .andExpect(jsonPath("$.accounts[1].name", equalTo(ACCOUNT_2.getName())))
                 .andExpect(jsonPath("$.accounts[1].timestamp", equalTo(ACCOUNT_2.getTimestamp().toString())));
     }
 


### PR DESCRIPTION
The SigninActivity now fetches accounts from the server when displaying the list of accounts to sign in with. No error handling is added yet (this will likely be done during the improve UI phase). The Account object in the app changed from an long timestamp to an Instant timestamp, and I added a new function to the AccountDao so that the results from the server can be added. I also changed the Account object in the server to have the `name` field, rather than the `accountName` field. This allows the app to easily parse the server's response using Jackson.