### PR TITLE
Invoke server's update sentiment endpoint from app

### DIFF
--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDaoTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDaoTest.java
@@ -19,6 +19,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import java.time.Instant;
 import java.util.List;
 
 @RunWith(AndroidJUnit4.class)
@@ -86,7 +87,7 @@ public class AssetSentimentDaoTest {
     public void addAndGetAsset_withSentiment_returnsAssetSentiment() {
         assetSentimentDao.addAsset(MOVIE_ASSET);
         assetSentimentDao.updateSentiment("accountName", "assetId",
-                AssetType.MOVIE, SentimentType.THUMBS_UP);
+                AssetType.MOVIE, SentimentType.THUMBS_UP, false, Instant.EPOCH);
 
         AssetSentiment result = LiveDataTestUtil.getValue(assetSentimentDao.getAsset("accountName",
                 "assetId", AssetType.MOVIE));
@@ -99,7 +100,7 @@ public class AssetSentimentDaoTest {
         assetSentimentDao.addAsset(MOVIE_ASSET);
 
         assetSentimentDao.updateSentiment("accountName", "assetId",
-                AssetType.MOVIE, SentimentType.UNSPECIFIED);
+                AssetType.MOVIE, SentimentType.UNSPECIFIED, false, Instant.EPOCH);
         List<AssetSentiment> results = LiveDataTestUtil.getValue(assetSentimentDao.getAssets(
                 AssetType.SHOW, "accountName", SentimentType.UNSPECIFIED));
 
@@ -111,7 +112,7 @@ public class AssetSentimentDaoTest {
         assetSentimentDao.addAsset(MOVIE_ASSET);
 
         assetSentimentDao.updateSentiment("accountName", "assetId",
-                AssetType.MOVIE, SentimentType.THUMBS_UP);
+                AssetType.MOVIE, SentimentType.THUMBS_UP, false, Instant.EPOCH);
         List<AssetSentiment> results = LiveDataTestUtil.getValue(assetSentimentDao.getAssets(
                 AssetType.MOVIE, "incorrectName", SentimentType.THUMBS_UP));
 
@@ -123,7 +124,7 @@ public class AssetSentimentDaoTest {
         assetSentimentDao.addAsset(MOVIE_ASSET);
 
         assetSentimentDao.updateSentiment("accountName", "assetId",
-                AssetType.MOVIE, SentimentType.THUMBS_UP);
+                AssetType.MOVIE, SentimentType.THUMBS_UP, false, Instant.EPOCH);
         List<AssetSentiment> results = LiveDataTestUtil.getValue(assetSentimentDao.getAssets(
                 AssetType.MOVIE, "accountName", SentimentType.THUMBS_DOWN));
 
@@ -136,9 +137,9 @@ public class AssetSentimentDaoTest {
         assetSentimentDao.addAsset(MOVIE_ASSET_2);
 
         assetSentimentDao.updateSentiment("accountName", "assetId",
-                AssetType.MOVIE, SentimentType.THUMBS_UP);
+                AssetType.MOVIE, SentimentType.THUMBS_UP, false, Instant.EPOCH);
         assetSentimentDao.updateSentiment("accountName", "assetId2",
-                AssetType.MOVIE, SentimentType.THUMBS_UP);
+                AssetType.MOVIE, SentimentType.THUMBS_UP, false, Instant.EPOCH);
         List<AssetSentiment> results = LiveDataTestUtil.getValue(assetSentimentDao.getAssets(
                 AssetType.MOVIE, "accountName", SentimentType.THUMBS_UP));
 
@@ -153,7 +154,7 @@ public class AssetSentimentDaoTest {
         assetSentimentDao.addAsset(MOVIE_ASSET_2);
 
         assetSentimentDao.updateSentiment("accountName", "assetId",
-                AssetType.MOVIE, SentimentType.UNSPECIFIED);
+                AssetType.MOVIE, SentimentType.UNSPECIFIED, false, Instant.EPOCH);
         List<AssetSentiment> results = LiveDataTestUtil.getValue(assetSentimentDao.getAssets(
                 AssetType.MOVIE, "accountName", SentimentType.UNSPECIFIED));
 
@@ -167,7 +168,7 @@ public class AssetSentimentDaoTest {
         assetSentimentDao.addAsset(MOVIE_ASSET);
 
         assetSentimentDao.updateSentiment("accountName", "assetId",
-                AssetType.MOVIE, SentimentType.THUMBS_UP);
+                AssetType.MOVIE, SentimentType.THUMBS_UP, false, Instant.EPOCH);
         assetSentimentDao.deleteAllSentiments("accountName");
         List<AssetSentiment> results = LiveDataTestUtil.getValue(assetSentimentDao.getAssets(
                 AssetType.MOVIE, "accountName", SentimentType.THUMBS_UP));
@@ -180,7 +181,7 @@ public class AssetSentimentDaoTest {
         assetSentimentDao.addAsset(MOVIE_ASSET);
 
         assetSentimentDao.updateSentiment("accountName", "assetId",
-                AssetType.MOVIE, SentimentType.THUMBS_UP);
+                AssetType.MOVIE, SentimentType.THUMBS_UP, false, Instant.EPOCH);
         assetSentimentDao.deleteAllSentiments("otherName");
         List<AssetSentiment> results = LiveDataTestUtil.getValue(assetSentimentDao.getAssets(
                 AssetType.MOVIE, "accountName", SentimentType.THUMBS_UP));

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragmentTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragmentTest.java
@@ -37,6 +37,7 @@ import com.google.moviestvsentiments.HiltFragmentScenario;
 import com.google.moviestvsentiments.usecase.details.DetailsActivity;
 import com.google.moviestvsentiments.usecase.signin.SigninActivity;
 import com.google.moviestvsentiments.util.AssetUtil;
+import java.time.Instant;
 
 @UninstallModules({DatabaseModule.class, WebModule.class})
 @HiltAndroidTest
@@ -98,7 +99,7 @@ public class AssetListFragmentTest {
             SentimentType sentimentType, AssetType assetType, int listId) {
         database.assetSentimentDao().addAsset(AssetUtil.createAsset("assetId1", assetType));
         database.assetSentimentDao().updateSentiment("Test Account", "assetId1",
-                assetType, sentimentType);
+                assetType, sentimentType, false, Instant.EPOCH);
         Intent intent = new Intent(ApplicationProvider.getApplicationContext(), HiltTestActivity.class);
         intent.putExtra(SigninActivity.EXTRA_ACCOUNT_NAME, "Test Account");
 
@@ -141,7 +142,7 @@ public class AssetListFragmentTest {
             SentimentType sentimentType, SentimentType otherSentiment, AssetType assetType) {
         database.assetSentimentDao().addAsset(AssetUtil.createAsset("assetId", assetType));
         database.assetSentimentDao().updateSentiment("Test Account", "assetId",
-                assetType, otherSentiment);
+                assetType, otherSentiment, false, Instant.EPOCH);
         Intent intent = new Intent(ApplicationProvider.getApplicationContext(), HiltTestActivity.class);
         intent.putExtra(SigninActivity.EXTRA_ACCOUNT_NAME, "Test Account");
 

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/webTestUtil/TestWebService.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/webTestUtil/TestWebService.java
@@ -6,6 +6,7 @@ import com.google.moviestvsentiments.model.Account;
 import com.google.moviestvsentiments.model.AssetSentiment;
 import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
+import com.google.moviestvsentiments.model.UserSentiment;
 import com.google.moviestvsentiments.service.web.ApiResponse;
 import com.google.moviestvsentiments.service.web.WebService;
 import java.time.Instant;
@@ -34,7 +35,14 @@ public class TestWebService implements WebService {
     }
 
     @Override
-    public LiveData<ApiResponse<List<AssetSentiment>>> getAssets(AssetType assetType, String accountName, SentimentType sentimentType) {
+    public LiveData<ApiResponse<List<AssetSentiment>>> getAssets(AssetType assetType,
+                                                 String accountName, SentimentType sentimentType) {
+        return new MutableLiveData<>(new ApiResponse(new RuntimeException(ERROR)));
+    }
+
+    @Override
+    public LiveData<ApiResponse<UserSentiment>> updateSentiment(String accountName, String assetId,
+                            AssetType assetType, SentimentType sentimentType, Instant timestamp) {
         return new MutableLiveData<>(new ApiResponse(new RuntimeException(ERROR)));
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/UserSentiment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/model/UserSentiment.java
@@ -31,4 +31,8 @@ public class UserSentiment {
     @NonNull
     @ColumnInfo(name = "timestamp", defaultValue = "CURRENT_TIMESTAMP")
     public Instant timestamp;
+
+    @NonNull
+    @ColumnInfo(name = "is_pending", defaultValue = "0")
+    public boolean isPending;
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDao.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDao.java
@@ -10,6 +10,7 @@ import com.google.moviestvsentiments.model.Asset;
 import com.google.moviestvsentiments.model.AssetSentiment;
 import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -127,12 +128,14 @@ public abstract class AssetSentimentDao {
      * @param assetId The id of the asset that the user sentiment is associated with.
      * @param assetType The type of the asset that the user sentiment is associated with.
      * @param sentimentType The type of the new user sentiment.
+     * @param isPending Whether the user sentiment needs to be synced with the server or not.
+     * @param timestamp The timestamp of the user sentiment.
      */
     @Query("INSERT OR REPLACE INTO user_sentiments_table " +
-            "(asset_id, account_name, asset_type, sentiment_type) " +
-            "VALUES (:assetId, :accountName, :assetType, :sentimentType)")
+            "(asset_id, account_name, asset_type, sentiment_type, is_pending, timestamp) " +
+            "VALUES (:assetId, :accountName, :assetType, :sentimentType, :isPending, :timestamp)")
     public abstract void updateSentiment(String accountName, String assetId, AssetType assetType,
-                                         SentimentType sentimentType);
+                                 SentimentType sentimentType, boolean isPending, Instant timestamp);
 
     /**
      * Deletes all user sentiments corresponding to the given account name.

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/WebService.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/WebService.java
@@ -5,11 +5,13 @@ import com.google.moviestvsentiments.model.Account;
 import com.google.moviestvsentiments.model.AssetSentiment;
 import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
+import com.google.moviestvsentiments.model.UserSentiment;
 import java.time.Instant;
 import java.util.List;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
+import retrofit2.http.PUT;
 import retrofit2.http.Query;
 
 /**
@@ -55,4 +57,21 @@ public interface WebService {
     LiveData<ApiResponse<List<AssetSentiment>>> getAssets(@Query("assetType") AssetType assetType,
                                               @Query("accountName") String accountName,
                                               @Query("sentimentType") SentimentType sentimentType);
+
+    /**
+     * Updates the UserSentiment on the remote server's database and returns the successfully
+     * saved UserSentiment.
+     * @param accountName The name of the account that the UserSentiment is associated with.
+     * @param assetId The id of the asset that the UserSentiment is associated with.
+     * @param assetType The type of the asset that the UserSentiment is associated with.
+     * @param sentimentType The type of the UserSentiment.
+     * @param timestamp The timestamp of the UserSentiment.
+     * @return The successfully saved UserSentiment.
+     */
+    @PUT("sentiment")
+    LiveData<ApiResponse<UserSentiment>> updateSentiment(@Query("accountName") String accountName,
+                                             @Query("assetId") String assetId,
+                                             @Query("assetType") AssetType assetType,
+                                             @Query("sentimentType") SentimentType sentimentType,
+                                             @Query("timestamp") Instant timestamp);
 }

--- a/server/src/main/java/com/google/moviestvsentiments/assetSentiment/AssetSentimentController.java
+++ b/server/src/main/java/com/google/moviestvsentiments/assetSentiment/AssetSentimentController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -45,6 +46,32 @@ public class AssetSentimentController {
         List<AssetSentiment> withoutReaction = assetSentimentRepository.getAssetsWithoutSentiment(assetType, accountName);
         withReaction.addAll(withoutReaction);
         return withReaction;
+    }
+
+    /**
+     * Inserts or replaces the UserSentiment with the given fields into the user sentiments table. If the UserSentiment
+     * is saved successfully, the saved version is returned. If the user sentiment cannot be saved, an error message is
+     * returned.
+     * @param accountName The name of the account associated with the UserSentiment.
+     * @param assetId The id of the asset associated with the UserSentiment.
+     * @param assetType The type of the asset associated with the UserSentiment.
+     * @param sentimentType The type of the UserSentiment.
+     * @param timestamp The timestamp of the UserSentiment.
+     * @return A ResponseEntity with either the saved UserSentiment or the error message.
+     */
+    @PutMapping("/sentiment")
+    public ResponseEntity updateSentiment(@RequestParam String accountName, @RequestParam String assetId,
+                                          @RequestParam AssetType assetType, @RequestParam SentimentType sentimentType,
+                                          @RequestParam Instant timestamp) {
+        try {
+            UserSentiment userSentiment = UserSentiment.create(accountName, assetId, assetType, sentimentType, timestamp);
+            userSentiment = userSentimentRepository.save(userSentiment);
+            return ResponseEntity.ok().body(userSentiment);
+        } catch (JpaSystemException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     /**

--- a/server/src/main/java/com/google/moviestvsentiments/assetSentiment/UserSentiment.java
+++ b/server/src/main/java/com/google/moviestvsentiments/assetSentiment/UserSentiment.java
@@ -72,6 +72,26 @@ public class UserSentiment {
     private Instant timestamp;
 
     /**
+     * Creates a new UserSentiment with the provided fields.
+     * @param accountName The name of the account associated with the UserSentiment.
+     * @param assetId The id of the asset associated with the UserSentiment.
+     * @param assetType The type of the asset associated with the UserSentiment.
+     * @param sentimentType The type of the UserSentiment.
+     * @param timestamp The timestamp of the UserSentiment.
+     * @return A new UserSentiment with the provided fields.
+     */
+    public static UserSentiment create(String accountName, String assetId, AssetType assetType,
+                                       SentimentType sentimentType, Instant timestamp) {
+        UserSentiment userSentiment = new UserSentiment();
+        userSentiment.accountName = accountName;
+        userSentiment.assetId = assetId;
+        userSentiment.assetType = assetType;
+        userSentiment.sentimentType = sentimentType;
+        userSentiment.timestamp = timestamp;
+        return userSentiment;
+    }
+
+    /**
      * Returns the id of the asset associated with this sentiment.
      */
     public String getAssetId() {


### PR DESCRIPTION
Adds a new endpoint to the server for updating a single sentiment value. Updates the app's AssetSentimentRepository to call this endpoint when a user sentiment is created/changed.