### PR TITLE
Sync pending accounts when coming back online

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId "com.google.moviestvsentiments"
-        minSdkVersion 16
+        minSdkVersion 24
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/webTestUtil/TestWebService.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/webTestUtil/TestWebService.java
@@ -30,8 +30,8 @@ public class TestWebService implements WebService {
     }
 
     @Override
-    public LiveData<ApiResponse<List<Account>>> addAccounts(List<Account> accounts) {
-        return new MutableLiveData<>(new ApiResponse(new RuntimeException(ERROR)));
+    public ApiResponse<List<Account>> syncPendingAccounts(List<Account> accounts) {
+        return new ApiResponse(new RuntimeException(ERROR));
     }
 
     @Override

--- a/MoviesTVSentiments/app/src/main/AndroidManifest.xml
+++ b/MoviesTVSentiments/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.google.moviestvsentiments">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:name=".MoviesTVSentimentsApplication"

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/MoviesTVSentimentsApplication.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/MoviesTVSentimentsApplication.java
@@ -1,6 +1,11 @@
 package com.google.moviestvsentiments;
 
 import android.app.Application;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import com.google.moviestvsentiments.service.account.AccountRepository;
+import javax.inject.Inject;
 import dagger.hilt.android.HiltAndroidApp;
 
 /**
@@ -8,4 +13,21 @@ import dagger.hilt.android.HiltAndroidApp;
  */
 @HiltAndroidApp
 public class MoviesTVSentimentsApplication extends Application {
+
+    @Inject
+    AccountRepository accountRepository;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        ConnectivityManager connectivityManager =
+                (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        connectivityManager.registerDefaultNetworkCallback(new ConnectivityManager.NetworkCallback() {
+            @Override
+            public void onAvailable(Network network) {
+                accountRepository.syncPendingAccounts();
+            }
+        });
+    }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/MoviesTVSentimentsApplication.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/MoviesTVSentimentsApplication.java
@@ -21,6 +21,7 @@ public class MoviesTVSentimentsApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
+        // TODO: schedule/retry syncing with server
         ConnectivityManager connectivityManager =
                 (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
         connectivityManager.registerDefaultNetworkCallback(new ConnectivityManager.NetworkCallback() {

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/di/WebModule.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/di/WebModule.java
@@ -3,6 +3,7 @@ package com.google.moviestvsentiments.di;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.moviestvsentiments.service.web.LiveDataCallAdapterFactory;
+import com.google.moviestvsentiments.service.web.SynchronousCallAdapterFactory;
 import com.google.moviestvsentiments.service.web.WebService;
 import javax.inject.Singleton;
 import dagger.Module;
@@ -35,6 +36,7 @@ public class WebModule {
                 .baseUrl(API_BASE_URL)
                 .addConverterFactory(JacksonConverterFactory.create(mapper))
                 .addCallAdapterFactory(new LiveDataCallAdapterFactory())
+                .addCallAdapterFactory(new SynchronousCallAdapterFactory())
                 .build();
         return retrofit.create(WebService.class);
     }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountDao.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountDao.java
@@ -62,4 +62,20 @@ public abstract class AccountDao {
     // to allow the public API to return a boolean.
     @Query("UPDATE accounts_table SET is_current = :isCurrent WHERE account_name = :name")
     protected abstract int setIsCurrentQuery(String name, boolean isCurrent);
+
+    /**
+     * Returns a list of all accounts that have isPending set to true.
+     */
+    @Query("SELECT * FROM accounts_table WHERE is_pending = 1")
+    public abstract List<Account> getPendingAccounts();
+
+    /**
+     * Sets isPending to false for each of the given Account names. This method should be used
+     * when the pending accounts have been successfully synced with the server. The addAccounts
+     * method cannot be used because the current account may have been pending, and the addAccounts
+     * method would replace the database record, clearing its isCurrent flag.
+     * @param accountNames The names of the Accounts whose isPending flag should be cleared.
+     */
+    @Query("UPDATE accounts_table SET is_pending = 0 WHERE account_name IN (:accountNames)")
+    public abstract void clearIsPending(List<String> accountNames);
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/SynchronousCallAdapter.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/SynchronousCallAdapter.java
@@ -1,0 +1,45 @@
+package com.google.moviestvsentiments.service.web;
+
+import java.lang.reflect.Type;
+import retrofit2.Call;
+import retrofit2.CallAdapter;
+import retrofit2.Response;
+
+/**
+ * A Retrofit adapter that synchronously executes a Call object and converts it into an ApiResponse.
+ * @param <T> The type of the Call and ApiResponse objects.
+ */
+public class SynchronousCallAdapter<T> implements CallAdapter<T, ApiResponse<T>> {
+
+    private final Type responseType;
+
+    private SynchronousCallAdapter(Type responseType) {
+        this.responseType = responseType;
+    }
+
+    /**
+     * Creates a new SynchronousCallAdapter with the given response type.
+     * @param responseType The value type that the adapter uses when converting the HTTP response
+     *                     body to a Java object.
+     * @param <T> The type of the Call and ApiResponse objects that will be used with the adapter.
+     * @return A new SynchronousCallAdapter with the given response type.
+     */
+    public static <T> SynchronousCallAdapter<T> create(Type responseType) {
+        return new SynchronousCallAdapter<>(responseType);
+    }
+
+    @Override
+    public Type responseType() {
+        return responseType;
+    }
+
+    @Override
+    public ApiResponse<T> adapt(Call<T> call) {
+        try {
+            Response<T> response = call.execute();
+            return new ApiResponse<>(response);
+        } catch (Exception e) {
+            return new ApiResponse<>(e);
+        }
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/SynchronousCallAdapterFactory.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/SynchronousCallAdapterFactory.java
@@ -1,0 +1,29 @@
+package com.google.moviestvsentiments.service.web;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import javax.annotation.Nullable;
+import retrofit2.CallAdapter;
+import retrofit2.Retrofit;
+
+/**
+ * A Retrofit CallAdapter factory that creates SynchronousCallAdapters.
+ */
+public class SynchronousCallAdapterFactory extends CallAdapter.Factory {
+
+    @Nullable
+    @Override
+    public CallAdapter<?, ?> get(Type returnType, Annotation[] annotations, Retrofit retrofit) {
+        if (getRawType(returnType) != ApiResponse.class) {
+            return null;
+        }
+
+        if (! (returnType instanceof ParameterizedType)) {
+            throw new IllegalArgumentException("Resource must be parameterized");
+        }
+
+        Type bodyType = getParameterUpperBound(0, (ParameterizedType) returnType);
+        return SynchronousCallAdapter.create(bodyType);
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/WebService.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/WebService.java
@@ -43,7 +43,7 @@ public interface WebService {
      * @return The list of successfully added Accounts.
      */
     @POST("accounts")
-    LiveData<ApiResponse<List<Account>>> addAccounts(@Body List<Account> accounts);
+    ApiResponse<List<Account>> syncPendingAccounts(@Body List<Account> accounts);
 
     /**
      * Returns a LiveData list of AssetSentiments that match the given AssetType, account name

--- a/MoviesTVSentiments/build.gradle
+++ b/MoviesTVSentiments/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.hiltVersion = '2.28-alpha'
     ext.jacocoVersion = '0.8.4'
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0-rc01'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hiltVersion"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.0"
         classpath "org.jacoco:org.jacoco.core:$jacocoVersion"


### PR DESCRIPTION
Adds a function to the AccountDao to get the list of all pending accounts and a function to the AccountRepository to sync pending accounts with the server. Registers a NetworkCallback on application startup that triggers when the default network becomes available. At that point, the pending accounts are synced with the server.