### PR TITLE
Use WorkManager to schedule sync with server

### DIFF
--- a/MoviesTVSentiments/app/build.gradle
+++ b/MoviesTVSentiments/app/build.gradle
@@ -119,6 +119,12 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-jackson:2.9.0'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.1'
 
+    // Work manager
+    implementation 'androidx.work:work-runtime:2.3.4'
+    implementation 'androidx.hilt:hilt-work:1.0.0-alpha01'
+    annotationProcessor 'androidx.hilt:hilt-compiler:1.0.0-alpha01'
+    androidTestImplementation 'androidx.work:work-testing:2.3.4'
+
     // Testing
     androidTestImplementation "androidx.test:rules:1.1.0"
     androidTestImplementation "androidx.arch.core:core-testing:$rootProject.coreTestingVersion"

--- a/MoviesTVSentiments/app/src/main/AndroidManifest.xml
+++ b/MoviesTVSentiments/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.google.moviestvsentiments">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -14,6 +15,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <provider
+            android:name="androidx.work.impl.WorkManagerInitializer"
+            android:authorities="${applicationId}.workmanager-init"
+            tools:node="remove" />
         <activity android:name=".usecase.details.DetailsActivity" />
         <activity android:name=".usecase.navigation.SentimentsNavigationActivity" />
         <activity android:name=".usecase.addAccount.AddAccountActivity" />

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/MoviesTVSentimentsApplication.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/MoviesTVSentimentsApplication.java
@@ -1,11 +1,17 @@
 package com.google.moviestvsentiments;
 
 import android.app.Application;
-import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.Network;
-import com.google.moviestvsentiments.service.account.AccountRepository;
-import com.google.moviestvsentiments.service.assetSentiment.AssetSentimentRepository;
+import androidx.annotation.NonNull;
+import androidx.hilt.work.HiltWorkerFactory;
+import androidx.work.Configuration;
+import androidx.work.Constraints;
+import androidx.work.NetworkType;
+import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkManager;
+import androidx.work.WorkRequest;
+import com.google.moviestvsentiments.service.account.AccountSyncWorker;
+import com.google.moviestvsentiments.service.assetSentiment.UserSentimentSyncWorker;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import dagger.hilt.android.HiltAndroidApp;
 
@@ -13,27 +19,33 @@ import dagger.hilt.android.HiltAndroidApp;
  * An application that uses Hilt for dependency injection.
  */
 @HiltAndroidApp
-public class MoviesTVSentimentsApplication extends Application {
+public class MoviesTVSentimentsApplication extends Application implements Configuration.Provider {
 
     @Inject
-    AccountRepository accountRepository;
-
-    @Inject
-    AssetSentimentRepository assetSentimentRepository;
+    HiltWorkerFactory workerFactory;
 
     @Override
     public void onCreate() {
         super.onCreate();
 
-        // TODO: schedule/retry syncing with server
-        ConnectivityManager connectivityManager =
-                (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-        connectivityManager.registerDefaultNetworkCallback(new ConnectivityManager.NetworkCallback() {
-            @Override
-            public void onAvailable(Network network) {
-                accountRepository.syncPendingAccounts();
-                assetSentimentRepository.syncPendingSentiments();
-            }
-        });
+        Constraints constraints = new Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED).build();
+        WorkRequest syncAccountsWorkRequest =
+                new PeriodicWorkRequest.Builder(AccountSyncWorker.class, 1, TimeUnit.HOURS)
+                .setConstraints(constraints)
+                .build();
+        WorkRequest syncSentimentsWorkRequest =
+                new PeriodicWorkRequest.Builder(UserSentimentSyncWorker.class, 1, TimeUnit.HOURS)
+                .setConstraints(constraints)
+                .build();
+
+        WorkManager.getInstance(getApplicationContext()).enqueue(syncAccountsWorkRequest);
+        WorkManager.getInstance(getApplicationContext()).enqueue(syncSentimentsWorkRequest);
+    }
+
+    @NonNull
+    @Override
+    public Configuration getWorkManagerConfiguration() {
+        return new Configuration.Builder().setWorkerFactory(workerFactory).build();
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountSyncWorker.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountSyncWorker.java
@@ -12,6 +12,8 @@ import androidx.work.WorkerParameters;
  */
 public class AccountSyncWorker extends Worker {
 
+    private static final int MAX_RUN_ATTEMPTS = 3;
+
     private final AccountRepository repository;
 
     @WorkerInject
@@ -24,6 +26,9 @@ public class AccountSyncWorker extends Worker {
 
     @Override
     public Result doWork() {
+        if (getRunAttemptCount() > MAX_RUN_ATTEMPTS) {
+            return Result.failure();
+        }
         if (repository.syncPendingAccounts()) {
             return Result.success();
         }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountSyncWorker.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/account/AccountSyncWorker.java
@@ -1,0 +1,32 @@
+package com.google.moviestvsentiments.service.account;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.hilt.Assisted;
+import androidx.hilt.work.WorkerInject;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+/**
+ * A Worker that syncs pending Accounts with the server.
+ */
+public class AccountSyncWorker extends Worker {
+
+    private final AccountRepository repository;
+
+    @WorkerInject
+    public AccountSyncWorker(@Assisted @NonNull Context context,
+                             @Assisted @NonNull WorkerParameters parameters,
+                             AccountRepository repository) {
+        super(context, parameters);
+        this.repository = repository;
+    }
+
+    @Override
+    public Result doWork() {
+        if (repository.syncPendingAccounts()) {
+            return Result.success();
+        }
+        return Result.retry();
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentRepository.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentRepository.java
@@ -156,19 +156,20 @@ public class AssetSentimentRepository {
 
     /**
      * Sends the list of pending UserSentiments to the server. If the server successfully saves them
-     * in its database, then the UserSentiments are updated locally to no longer be pending.
+     * in its database, then the UserSentiments are updated locally to no longer be pending. This
+     * method should not be called from the main thread.
+     * @return True if the UserSentiments are saved correctly.
      */
-    public void syncPendingSentiments() {
-        executor.execute(() -> {
-            List<UserSentiment> pendingSentiments = assetSentimentDao.getPendingSentiments();
-            if (pendingSentiments.isEmpty()) {
-                return;
-            }
+    public boolean syncPendingSentiments() {
+        List<UserSentiment> pendingSentiments = assetSentimentDao.getPendingSentiments();
+        if (pendingSentiments.isEmpty()) {
+            return true;
+        }
 
-            ApiResponse<List<UserSentiment>> response = webService.syncPendingSentiments(pendingSentiments);
-            if (response.isSuccessful()) {
-                assetSentimentDao.updateSentiments(response.getBody());
-            }
-        });
+        ApiResponse<List<UserSentiment>> response = webService.syncPendingSentiments(pendingSentiments);
+        if (response.isSuccessful()) {
+            assetSentimentDao.updateSentiments(response.getBody());
+        }
+        return response.isSuccessful();
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/UserSentimentSyncWorker.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/UserSentimentSyncWorker.java
@@ -1,0 +1,32 @@
+package com.google.moviestvsentiments.service.assetSentiment;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.hilt.Assisted;
+import androidx.hilt.work.WorkerInject;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+/**
+ * A Worker that syncs pending UserSentiments with the server.
+ */
+public class UserSentimentSyncWorker extends Worker {
+
+    private final AssetSentimentRepository repository;
+
+    @WorkerInject
+    public UserSentimentSyncWorker(@Assisted @NonNull Context context,
+                                   @Assisted @NonNull WorkerParameters parameters,
+                                   AssetSentimentRepository repository) {
+        super(context, parameters);
+        this.repository = repository;
+    }
+
+    @Override
+    public Result doWork() {
+        if (repository.syncPendingSentiments()) {
+            return Result.success();
+        }
+        return Result.retry();
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/UserSentimentSyncWorker.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/UserSentimentSyncWorker.java
@@ -12,6 +12,8 @@ import androidx.work.WorkerParameters;
  */
 public class UserSentimentSyncWorker extends Worker {
 
+    private static final int MAX_RUN_ATTEMPTS = 3;
+
     private final AssetSentimentRepository repository;
 
     @WorkerInject
@@ -24,6 +26,9 @@ public class UserSentimentSyncWorker extends Worker {
 
     @Override
     public Result doWork() {
+        if (getRunAttemptCount() > MAX_RUN_ATTEMPTS) {
+            return Result.failure();
+        }
         if (repository.syncPendingSentiments()) {
             return Result.success();
         }


### PR DESCRIPTION
Instead of syncing only when the app restarts or the network connection comes back online, the app will now sync with the server every hour. If the sync fails, it will retry using WorkManager's default exponential backoff. 