### PR TITLE
Scrape Asset banner images

### DIFF
--- a/server/src/main/java/com/google/moviestvsentiments/assetSentiment/Asset.java
+++ b/server/src/main/java/com/google/moviestvsentiments/assetSentiment/Asset.java
@@ -65,7 +65,7 @@ public class Asset {
 
     private String title;
     private String poster;
-    private String banner;
+    @Lob private String banner;
     private String imdbRating;
     private String rottenTomatoesRating;
     @Lob private String plot;

--- a/server/src/main/java/com/google/moviestvsentiments/assetSentiment/AssetSentimentRepository.java
+++ b/server/src/main/java/com/google/moviestvsentiments/assetSentiment/AssetSentimentRepository.java
@@ -11,6 +11,12 @@ import java.util.List;
 public interface AssetSentimentRepository extends PagingAndSortingRepository<Asset, Asset.AssetCompositeKey> {
 
     /**
+     * Returns a list of Assets that have a null banner image URL.
+     */
+    @Query("SELECT asset FROM Asset asset WHERE asset.banner IS NULL")
+    List<Asset> getAssetsWithoutBanner();
+
+    /**
      * Returns a list of AssetSentiments with reactions that match the given account name and sentiment type.
      * @param assetType The type of asset to include in the results.
      * @param accountName The account name to use when checking assets for sentiments.

--- a/server/src/main/java/com/google/moviestvsentiments/webscrape/AssetScrapeController.java
+++ b/server/src/main/java/com/google/moviestvsentiments/webscrape/AssetScrapeController.java
@@ -6,8 +6,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -40,5 +42,29 @@ public class AssetScrapeController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
+    }
+
+    /**
+     * Scrapes banner images for Assets that don't currently have a banner and then updates the Asset in the database.
+     * If some Assets are not successfully updated, their ids are returned.
+     * @param apiKey The Google Cloud api key to use when searching for banner images.
+     * @return A list of ids of Assets that did not save successfully.
+     */
+    @PutMapping("/banners")
+    public ResponseEntity scrapeBanners(@RequestParam("apiKey") String apiKey) {
+        List<String> failedIds = new ArrayList<>();
+
+        List<Asset> assets = assetSentimentRepository.getAssetsWithoutBanner();
+        for (Asset asset : assets) {
+            try {
+                String bannerUrl = assetScraper.scrapeBannerUrl(apiKey, asset);
+                asset.setBanner(bannerUrl);
+                assetSentimentRepository.save(asset);
+            } catch (Exception e) {
+                failedIds.add(asset.getAssetId());
+            }
+        }
+
+        return ResponseEntity.ok().body(failedIds);
     }
 }

--- a/server/src/test/java/com/google/moviestvsentiments/webscrape/AssetScrapeControllerTest.java
+++ b/server/src/test/java/com/google/moviestvsentiments/webscrape/AssetScrapeControllerTest.java
@@ -1,11 +1,12 @@
 package com.google.moviestvsentiments.webscrape;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -29,7 +30,8 @@ public class AssetScrapeControllerTest {
 
     private static final String OMDB_URL = "testurl";
     private static final String API_KEY = "testApiKey";
-    private static final String TEST_URL = "/scrape?url=" + OMDB_URL + "&apiKey=" + API_KEY;
+    private static final String SCRAPE_ASSETS_TEST_URL = "/scrape?url=" + OMDB_URL + "&apiKey=" + API_KEY;
+    private static final String SCRAPE_BANNERS_TEST_URL = "/banners?apiKey=" + API_KEY;
 
     @Autowired
     private MockMvc mockMvc;
@@ -48,11 +50,11 @@ public class AssetScrapeControllerTest {
         when(scraper.scrapeIds(OMDB_URL)).thenReturn(assetIds);
         when(scraper.scrapeAssets(assetIds, API_KEY)).thenReturn(assets);
 
-        mockMvc.perform(get(TEST_URL));
+        mockMvc.perform(get(SCRAPE_ASSETS_TEST_URL));
 
-        verify(scraper, times(1)).scrapeIds(OMDB_URL);
-        verify(scraper, times(1)).scrapeAssets(assetIds, API_KEY);
-        verify(repository, times(1)).saveAll(assets);
+        verify(scraper).scrapeIds(OMDB_URL);
+        verify(scraper).scrapeAssets(assetIds, API_KEY);
+        verify(repository).saveAll(assets);
         verifyNoMoreInteractions(scraper, repository);
     }
 
@@ -64,7 +66,7 @@ public class AssetScrapeControllerTest {
         when(scraper.scrapeIds(OMDB_URL)).thenReturn(assetIds);
         when(scraper.scrapeAssets(assetIds, API_KEY)).thenReturn(assets);
 
-        mockMvc.perform(get(TEST_URL)).andExpect(status().isOk());
+        mockMvc.perform(get(SCRAPE_ASSETS_TEST_URL)).andExpect(status().isOk());
     }
 
     @Test
@@ -72,8 +74,31 @@ public class AssetScrapeControllerTest {
         final String errorMessage = "Failed to scrape Asset ids";
         when(scraper.scrapeIds(OMDB_URL)).thenThrow(new IOException(errorMessage));
 
-        mockMvc.perform(get(TEST_URL))
+        mockMvc.perform(get(SCRAPE_ASSETS_TEST_URL))
                 .andExpect(status().is5xxServerError())
                 .andExpect(jsonPath("$", equalTo(errorMessage)));
+    }
+
+    @Test
+    public void scrapeBanners_successful_savesAsset() throws Exception {
+        final String bannerUrl = "testBannerUrl";
+        Asset asset = AssetUtil.createAsset("assetId1", AssetType.MOVIE, "title1");
+        when(repository.getAssetsWithoutBanner()).thenReturn(Arrays.asList(asset));
+        when(scraper.scrapeBannerUrl(API_KEY, asset)).thenReturn(bannerUrl);
+
+        mockMvc.perform(put(SCRAPE_BANNERS_TEST_URL));
+
+        assertThat(asset.getBanner()).isEqualTo(bannerUrl);
+        verify(repository).save(asset);
+    }
+
+    @Test
+    public void scrapeBanners_failure_returnsAssetId() throws Exception {
+        Asset asset = AssetUtil.createAsset("assetId1", AssetType.MOVIE, "title1");
+        when(repository.getAssetsWithoutBanner()).thenReturn(Arrays.asList(asset));
+        when(scraper.scrapeBannerUrl(API_KEY, asset)).thenThrow(new RuntimeException("Scrape failure"));
+
+        mockMvc.perform(put(SCRAPE_BANNERS_TEST_URL))
+                .andExpect(jsonPath("$[0]", equalTo("assetId1")));
     }
 }


### PR DESCRIPTION
Adds an endpoint to the server that will scrape banner image URLs for any assets that have a null banner image URL. Adds two tests for this endpoint and cleans up the existing tests in that test class. The endpoint will be manually called from Postman just to get demo data.