### PR TITLE
Improve CI test reliability

### DIFF
--- a/.github/workflows/test-workflow.yaml
+++ b/.github/workflows/test-workflow.yaml
@@ -26,7 +26,7 @@ jobs:
           path: /Users/runner/work/play-movies-2020-intern/play-movies-2020-intern/server/build/reports/tests/test/
 
       - name: Run app JUnit and Espresso tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2.11.0
         if: ${{ !cancelled() }}
         with:
           working-directory: ./MoviesTVSentiments

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDao.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDao.java
@@ -120,7 +120,7 @@ public abstract class AssetSentimentDao {
         if (other.getValue() != null) {
             result.addAll(other.getValue());
         }
-        mediator.setValue(result);
+        mediator.postValue(result);
     }
 
     /**

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/NetworkBoundResource.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/web/NetworkBoundResource.java
@@ -18,7 +18,7 @@ public abstract class NetworkBoundResource<ServerType, LocalType> {
      * may or may not trigger a network request.
      */
     public NetworkBoundResource() {
-        result.setValue(Resource.loading(null));
+        result.postValue(Resource.loading(null));
         LiveData<LocalType> dbSource = loadFromRoom();
         result.addSource(dbSource, data -> {
             result.removeSource(dbSource);
@@ -80,7 +80,7 @@ public abstract class NetworkBoundResource<ServerType, LocalType> {
      */
     private void setValue(Resource<LocalType> newValue) {
         if (!Objects.equals(result.getValue(), newValue)) {
-            result.setValue(newValue);
+            result.postValue(newValue);
         }
     }
 

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragment.java
@@ -64,6 +64,14 @@ public class AssetListFragment extends Fragment implements AssetListAdapter.Asse
         return root;
     }
 
+    @Override
+    public void onStop() {
+        super.onStop();
+        if (assetReactSheet != null) {
+            assetReactSheet.dismiss();
+        }
+    }
+
     /**
      * Sends an intent containing the current account name and the given AssetSentiment object to
      * the DetailsActivity.

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetReactSheet.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetReactSheet.java
@@ -148,4 +148,13 @@ public class AssetReactSheet {
     public void show() {
         sheetDialog.show();
     }
+
+    /**
+     * Dismisses the AssetReactSheet.
+     */
+    public void dismiss() {
+        if (sheetDialog.isShowing()) {
+            sheetDialog.dismiss();
+        }
+    }
 }


### PR DESCRIPTION
Adds a few different things I've been experimenting with to get the CI tests more reliable. I ran this about 10 times, and it failed 2 times, which I think is probably better than before.

Changes:
- Use the most recent version of the android emulator runner Github action
- Change the way the SentimentsNavigationActivityTest clicks the menu button and the sign out button. This avoids an issue where the test failed because the sign out button wasn't fully on screen yet
- Convert all instances of LiveData.setValue to LiveData.postValue
- Dismiss the AssetReactSheet when the AssetListFragment is stopped. This prevents an error where the dialog sheet window was being leaked by the test class