### PR TITLE
Add toast for offline mode

### DIFF
--- a/MoviesTVSentiments/.idea/compiler.xml
+++ b/MoviesTVSentiments/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/MoviesTVSentiments/.idea/gradle.xml
+++ b/MoviesTVSentiments/.idea/gradle.xml
@@ -15,6 +15,7 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
+        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/MoviesTVSentiments/.idea/misc.xml
+++ b/MoviesTVSentiments/.idea/misc.xml
@@ -39,7 +39,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/HiltFragmentScenario.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/HiltFragmentScenario.java
@@ -16,11 +16,13 @@ public class HiltFragmentScenario {
      * @param fragmentClass The class of the fragment to instantiate.
      * @param args The arguments to pass to the fragment.
      * @param <F> The type of the fragment.
+     * @return The ActivityScenario used to launch the HiltTestActivity.
      */
-    public static <F extends Fragment> void launchHiltFragment(Class<F> fragmentClass, Bundle args) {
+    public static <F extends Fragment> ActivityScenario launchHiltFragment(Class<F> fragmentClass,
+                                                                           Bundle args) {
         Intent intent = new Intent(ApplicationProvider.getApplicationContext(),
                 HiltTestActivity.class);
-        launchHiltFragmentWithIntent(fragmentClass, intent, args);
+        return launchHiltFragmentWithIntent(fragmentClass, intent, args);
     }
 
     /**
@@ -30,9 +32,10 @@ public class HiltFragmentScenario {
      * @param intent The intent to use when launching the hosting activity.
      * @param args The arguments to pass to the fragment.
      * @param <F> The type of the fragment.
+     * @return The ActivityScenario used to launch the provided intent.
      */
-    public static <F extends Fragment> void launchHiltFragmentWithIntent(Class<F> fragmentClass,
-                                                                     Intent intent, Bundle args) {
+    public static <F extends Fragment> ActivityScenario launchHiltFragmentWithIntent(
+                Class<F> fragmentClass, Intent intent, Bundle args) {
         ActivityScenario<HiltTestActivity> activityScenario = ActivityScenario.launch(intent);
         activityScenario.onActivity(activity -> {
             Fragment fragment = activity.getSupportFragmentManager().getFragmentFactory()
@@ -43,5 +46,6 @@ public class HiltFragmentScenario {
                     .add(android.R.id.content, fragment, null)
                     .commitNow();
         });
+        return activityScenario;
     }
 }

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/HiltTestRunner.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/HiltTestRunner.java
@@ -3,7 +3,6 @@ package com.google.moviestvsentiments;
 import android.app.Application;
 import android.content.Context;
 import androidx.test.runner.AndroidJUnitRunner;
-import dagger.hilt.android.testing.HiltTestApplication;
 
 /**
  * A test runner that uses Hilt for dependency injection.
@@ -13,6 +12,6 @@ public class HiltTestRunner extends AndroidJUnitRunner {
     @Override
     public Application newApplication(ClassLoader cl, String className, Context context)
         throws ClassNotFoundException, IllegalAccessException, InstantiationException {
-        return super.newApplication(cl, HiltTestApplication.class.getName(), context);
+        return super.newApplication(cl, MoviesTVSentimentsTest_Application.class.getName(), context);
     }
 }

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/MoviesTVSentimentsTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/MoviesTVSentimentsTest.java
@@ -1,0 +1,9 @@
+package com.google.moviestvsentiments;
+
+import dagger.hilt.android.testing.CustomTestApplication;
+
+/**
+ * A custom test application that allows toasts to be displayed in Hilt Espresso tests.
+ */
+@CustomTestApplication(ToastApplication.class)
+public interface MoviesTVSentimentsTest { }

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragmentTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragmentTest.java
@@ -7,6 +7,8 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra;
+import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -15,10 +17,12 @@ import static com.google.moviestvsentiments.assertions.RecyclerViewItemCountAsse
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 import android.content.Intent;
 import android.os.Bundle;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.intent.Intents;
 import com.google.moviestvsentiments.HiltTestActivity;
@@ -70,6 +74,17 @@ public class AssetListFragmentTest {
     @Before
     public void setUp() {
         hiltAndroidRule.inject();
+    }
+
+    @Test
+    public void serverError_displaysOfflineToast() {
+        ActivityScenario activityScenario = HiltFragmentScenario.launchHiltFragment(AssetListFragment.class,
+                createFragmentArgs(SentimentType.UNSPECIFIED));
+
+        activityScenario.onActivity(activity -> {
+            onView(withText(R.string.offlineToast)).inRoot(withDecorView(not(
+                    activity.getWindow().getDecorView()))).check(matches(isDisplayed()));
+        });
     }
 
     private Object[] startsWithEmptyListValues() {

--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
@@ -7,6 +7,8 @@ import static androidx.test.espresso.intent.Intents.intended;
 import static androidx.test.espresso.intent.Intents.intending;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra;
+import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
@@ -14,6 +16,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.google.moviestvsentiments.assertions.RecyclerViewItemCountAssertion.withItemCount;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 import android.app.Activity;
 import android.app.Instrumentation.ActivityResult;
@@ -37,10 +40,18 @@ import com.google.moviestvsentiments.usecase.navigation.SentimentsNavigationActi
 @HiltAndroidTest
 public class SigninActivityTest {
 
+    IntentsTestRule<SigninActivity> intentsRule = new IntentsTestRule<>(SigninActivity.class);
+
     @Rule
     public RuleChain rule = RuleChain.outerRule(new HiltAndroidRule(this))
-            .around(new IntentsTestRule<>(SigninActivity.class))
+            .around(intentsRule)
             .around(new InstantTaskExecutorRule());
+
+    @Test
+    public void serverError_displaysToast() {
+        onView(withText(R.string.offlineToast)).inRoot(withDecorView(not(intentsRule.getActivity()
+                .getWindow().getDecorView()))).check(matches(isDisplayed()));
+    }
 
     @Test
     public void signinActivity_displaysOnlyAddAccount() {

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/MoviesTVSentimentsApplication.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/MoviesTVSentimentsApplication.java
@@ -1,6 +1,5 @@
 package com.google.moviestvsentiments;
 
-import android.app.Application;
 import androidx.annotation.NonNull;
 import androidx.hilt.work.HiltWorkerFactory;
 import androidx.work.Configuration;
@@ -19,10 +18,12 @@ import dagger.hilt.android.HiltAndroidApp;
  * An application that uses Hilt for dependency injection.
  */
 @HiltAndroidApp
-public class MoviesTVSentimentsApplication extends Application implements Configuration.Provider {
+public class MoviesTVSentimentsApplication extends ToastApplication implements Configuration.Provider {
 
     @Inject
     HiltWorkerFactory workerFactory;
+
+    private boolean toastDisplayed;
 
     @Override
     public void onCreate() {
@@ -47,5 +48,17 @@ public class MoviesTVSentimentsApplication extends Application implements Config
     @Override
     public Configuration getWorkManagerConfiguration() {
         return new Configuration.Builder().setWorkerFactory(workerFactory).build();
+    }
+
+    /**
+     * Displays a toast notifying the user that the app is in offline mode only if the toast
+     * has not already been displayed. This method should only be called on the main thread.
+     */
+    @Override
+    public void displayOfflineToast() {
+        if (!toastDisplayed) {
+            toastDisplayed = true;
+            super.displayOfflineToast();
+        }
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/ToastApplication.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/ToastApplication.java
@@ -1,0 +1,17 @@
+package com.google.moviestvsentiments;
+
+import android.app.Application;
+import android.widget.Toast;
+
+/**
+ * An Application that provides methods for displaying toasts.
+ */
+public class ToastApplication extends Application {
+
+    /**
+     * Displays a toast notifying the user that the app is in offline mode.
+     */
+    public void displayOfflineToast() {
+        Toast.makeText(getApplicationContext(), R.string.offlineToast, Toast.LENGTH_LONG).show();
+    }
+}

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragment.java
@@ -9,10 +9,12 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.ToastApplication;
 import com.google.moviestvsentiments.model.AssetSentiment;
 import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
 import com.google.moviestvsentiments.service.assetSentiment.AssetSentimentViewModel;
+import com.google.moviestvsentiments.service.web.Resource;
 import com.google.moviestvsentiments.usecase.details.DetailsActivity;
 import com.google.moviestvsentiments.usecase.signin.SigninActivity;
 import javax.inject.Inject;
@@ -52,12 +54,18 @@ public class AssetListFragment extends Fragment implements AssetListAdapter.Asse
                 if (moviesResource.getValue() != null) {
                     assetListScreen.setMovies(moviesResource.getValue());
                 }
+                if (moviesResource.getStatus() == Resource.Status.ERROR) {
+                    ((ToastApplication) getActivity().getApplication()).displayOfflineToast();
+                }
             });
 
         viewModel.getAssets(AssetType.SHOW, accountName, sentimentType)
             .observe(getViewLifecycleOwner(), showsResource -> {
                 if (showsResource.getValue() != null) {
                     assetListScreen.setShows(showsResource.getValue());
+                }
+                if (showsResource.getStatus() == Resource.Status.ERROR) {
+                    ((ToastApplication) getActivity().getApplication()).displayOfflineToast();
                 }
             });
 

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/signin/SigninActivity.java
@@ -7,7 +7,9 @@ import androidx.recyclerview.widget.RecyclerView;
 import android.content.Intent;
 import android.os.Bundle;
 import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.ToastApplication;
 import com.google.moviestvsentiments.service.account.AccountViewModel;
+import com.google.moviestvsentiments.service.web.Resource;
 import com.google.moviestvsentiments.usecase.addAccount.AddAccountActivity;
 import com.google.moviestvsentiments.usecase.navigation.SentimentsNavigationActivity;
 import dagger.hilt.android.AndroidEntryPoint;
@@ -54,6 +56,9 @@ public class SigninActivity extends AppCompatActivity implements AccountListAdap
         viewModel.getAlphabetizedAccounts().observe(this, resource -> {
             if (resource.getValue() != null) {
                 adapter.setAccounts(resource.getValue());
+            }
+            if (resource.getStatus() == Resource.Status.ERROR) {
+                ((ToastApplication) getApplication()).displayOfflineToast();
             }
         });
     }

--- a/MoviesTVSentiments/app/src/main/res/values/strings.xml
+++ b/MoviesTVSentiments/app/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
     <string name="close_drawer">Close Navigation Drawer</string>
     <string name="signoutLabel">Sign Out</string>
     <string name="signinTitle">Sign In</string>
+    <string name="offlineToast">Could not fetch data. Continuing in offline mode. Some results may be outdated.</string>
 </resources>


### PR DESCRIPTION
Displays a toast informing the user that the app is in offline mode if a network request fails. The toast is only displayed on the first failure since app launch, that way the user is not continuously seeing the notification. The toast is displayed on the AssetListFragment and the SigninActivity when fetching AssetSentiment and Account data. The toast is not displayed if a failure occurs when updating data. 

<img width="352" alt="Screen Shot 2020-07-27 at 2 57 57 PM" src="https://user-images.githubusercontent.com/22841845/88591717-66c6ee00-d022-11ea-8d0e-6452cbd797f8.png">
