### PR TITLE
Fix toast tests, wrap text in DetailsActivity

### DIFF
--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/signin/SigninActivityTest.java
@@ -13,6 +13,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibilit
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static com.google.moviestvsentiments.assertions.RecyclerViewItemCountAssertion.withItemCount;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -31,6 +32,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.espresso.matcher.ViewMatchers;
 import com.google.moviestvsentiments.R;
+import com.google.moviestvsentiments.ToastApplication;
 import com.google.moviestvsentiments.di.DatabaseModule;
 import com.google.moviestvsentiments.di.WebModule;
 import com.google.moviestvsentiments.usecase.addAccount.AddAccountActivity;
@@ -40,7 +42,8 @@ import com.google.moviestvsentiments.usecase.navigation.SentimentsNavigationActi
 @HiltAndroidTest
 public class SigninActivityTest {
 
-    IntentsTestRule<SigninActivity> intentsRule = new IntentsTestRule<>(SigninActivity.class);
+    IntentsTestRule<SigninActivity> intentsRule = new IntentsTestRule<>(SigninActivity.class, false,
+            false);
 
     @Rule
     public RuleChain rule = RuleChain.outerRule(new HiltAndroidRule(this))
@@ -49,30 +52,42 @@ public class SigninActivityTest {
 
     @Test
     public void serverError_displaysToast() {
+        ((ToastApplication)getInstrumentation().getTargetContext().getApplicationContext())
+                .resetToastDisplayed();
+        intentsRule.launchActivity(null);
+
         onView(withText(R.string.offlineToast)).inRoot(withDecorView(not(intentsRule.getActivity()
                 .getWindow().getDecorView()))).check(matches(isDisplayed()));
     }
 
     @Test
     public void signinActivity_displaysOnlyAddAccount() {
+        intentsRule.launchActivity(null);
+
         onView(withId(R.id.accountList)).check(withItemCount(1));
         onView(withId(R.id.accountTextView)).check(matches(withText("Add Account")));
     }
 
     @Test
     public void addAccount_displaysCorrectIcon() {
+        intentsRule.launchActivity(null);
+
         onView(withId(R.id.accountIcon)).check(matches(withTagValue(equalTo(
                 R.drawable.ic_baseline_person_add_24))));
     }
 
     @Test
     public void addAccount_hidesIconTextView() {
+        intentsRule.launchActivity(null);
+
         onView(withId(R.id.accountIconText)).check(matches(withEffectiveVisibility(
                 ViewMatchers.Visibility.GONE)));
     }
 
     @Test
     public void signinActivity_clickAddAccount_sendsIntentToAddAccountActivity() {
+        intentsRule.launchActivity(null);
+
         onView(withId(R.id.accountTextView)).perform(click());
 
         intended(hasComponent(AddAccountActivity.class.getName()));
@@ -80,6 +95,7 @@ public class SigninActivityTest {
 
     @Test
     public void signinActivity_addAccountResultCanceled_displaysOnlyAddAccount() {
+        intentsRule.launchActivity(null);
         ActivityResult result = new ActivityResult(Activity.RESULT_CANCELED, new Intent());
         intending(hasComponent(AddAccountActivity.class.getName())).respondWith(result);
 
@@ -91,6 +107,7 @@ public class SigninActivityTest {
 
     @Test
     public void signinActivity_addAccountResultOk_displaysNewAccount() {
+        intentsRule.launchActivity(null);
         Intent intent = new Intent();
         intent.putExtra(AddAccountActivity.EXTRA_ACCOUNT_NAME, "Account Name");
         ActivityResult result = new ActivityResult(Activity.RESULT_OK, intent);
@@ -105,6 +122,7 @@ public class SigninActivityTest {
 
     @Test
     public void signinActivity_clickAccountName_sendsIntentToSentimentsNavigationActivity() {
+        intentsRule.launchActivity(null);
         Intent intent = new Intent();
         intent.putExtra(AddAccountActivity.EXTRA_ACCOUNT_NAME, "Account Name");
         ActivityResult result = new ActivityResult(Activity.RESULT_OK, intent);

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/MoviesTVSentimentsApplication.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/MoviesTVSentimentsApplication.java
@@ -23,8 +23,6 @@ public class MoviesTVSentimentsApplication extends ToastApplication implements C
     @Inject
     HiltWorkerFactory workerFactory;
 
-    private boolean toastDisplayed;
-
     @Override
     public void onCreate() {
         super.onCreate();
@@ -48,17 +46,5 @@ public class MoviesTVSentimentsApplication extends ToastApplication implements C
     @Override
     public Configuration getWorkManagerConfiguration() {
         return new Configuration.Builder().setWorkerFactory(workerFactory).build();
-    }
-
-    /**
-     * Displays a toast notifying the user that the app is in offline mode only if the toast
-     * has not already been displayed. This method should only be called on the main thread.
-     */
-    @Override
-    public void displayOfflineToast() {
-        if (!toastDisplayed) {
-            toastDisplayed = true;
-            super.displayOfflineToast();
-        }
     }
 }

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/ToastApplication.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/ToastApplication.java
@@ -2,16 +2,31 @@ package com.google.moviestvsentiments;
 
 import android.app.Application;
 import android.widget.Toast;
+import androidx.annotation.VisibleForTesting;
 
 /**
  * An Application that provides methods for displaying toasts.
  */
 public class ToastApplication extends Application {
 
+    private boolean toastDisplayed;
+
     /**
      * Displays a toast notifying the user that the app is in offline mode.
      */
     public void displayOfflineToast() {
-        Toast.makeText(getApplicationContext(), R.string.offlineToast, Toast.LENGTH_LONG).show();
+        if (!toastDisplayed) {
+            toastDisplayed = true;
+            Toast.makeText(getApplicationContext(), R.string.offlineToast, Toast.LENGTH_LONG).show();
+        }
+    }
+
+    /**
+     * Resets the toastDisplayed flag to false so that tests of the toast can make sure it is
+     * displayed.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public void resetToastDisplayed() {
+        toastDisplayed = false;
     }
 }

--- a/MoviesTVSentiments/app/src/main/res/layouts/details/layout/activity_details.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/details/layout/activity_details.xml
@@ -72,9 +72,12 @@
 
         <TextView
             android:id="@+id/asset_title"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/bigPadding"
+            android:layout_marginRight="@dimen/bigPadding"
+            android:maxLines="2"
+            android:ellipsize="end"
             android:text="Movie/Show Name"
             android:textColor="@color/text"
             android:textSize="20sp"


### PR DESCRIPTION
The tests of the offline toast were failing because Espresso does not restart the application between different test methods. This caused an error where the application was prevented from showing toasts in tests because it had already shown 25 toasts. To fix this, I moved the logic that ensures the toast is only shown once into the base ToastApplication class. Doing this caused an issue where the toast tests would run after the toast had already displayed and would not be able to display them again, thus causing a failure. To fix this, I added a method to the ToastApplication class that resets the `toastDisplayed` flag and made it visible only in the tests.

I also made a slight change to the DetailsActivity that allows the title text to wrap instead of just continuing off screen.