### PR TITLE
Improve UI when there are no assets

### DIFF
--- a/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragmentTest.java
+++ b/MoviesTVSentiments/app/src/androidTest/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragmentTest.java
@@ -9,6 +9,7 @@ import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra;
 import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
@@ -26,6 +27,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.fragment.app.Fragment;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.intent.Intents;
+import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.rule.ActivityTestRule;
 import com.google.moviestvsentiments.HiltTestActivity;
 import com.google.moviestvsentiments.R;
@@ -102,7 +104,7 @@ public class AssetListFragmentTest {
                 .getActivity().getWindow().getDecorView()))).check(matches(isDisplayed()));
     }
 
-    private Object[] startsWithEmptyListValues() {
+    private Object[] sentimentTypeValues() {
         return new Object[] {
             new Object[] {SentimentType.UNSPECIFIED},
             new Object[] {SentimentType.THUMBS_UP},
@@ -111,13 +113,62 @@ public class AssetListFragmentTest {
     }
 
     @Test
-    @Parameters(method = "startsWithEmptyListValues")
+    @Parameters(method = "sentimentTypeValues")
     public void assetListFragment_startsWithEmptyList(SentimentType sentimentType) {
         HiltFragmentScenario.launchHiltFragment(AssetListFragment.class,
                 createFragmentArgs(sentimentType));
 
         onView(withId(R.id.movies_list)).check(withItemCount(0));
         onView(withId(R.id.tvshows_list)).check(withItemCount(0));
+    }
+
+    @Test
+    @Parameters(method = "sentimentTypeValues")
+    public void assetListFragment_emptyList_hidesRecyclerView(SentimentType sentimentType) {
+        HiltFragmentScenario.launchHiltFragment(AssetListFragment.class,
+                createFragmentArgs(sentimentType));
+
+        onView(withId(R.id.movies_list)).check(matches(withEffectiveVisibility(
+                ViewMatchers.Visibility.GONE)));
+        onView(withId(R.id.tvshows_list)).check(matches(withEffectiveVisibility(
+                ViewMatchers.Visibility.GONE)));
+    }
+
+    @Test
+    @Parameters(method = "sentimentTypeValues")
+    public void assetListFragment_emptyList_hidesLabels(SentimentType sentimentType) {
+        HiltFragmentScenario.launchHiltFragment(AssetListFragment.class,
+                createFragmentArgs(sentimentType));
+
+        onView(withId(R.id.movies_label)).check(matches(withEffectiveVisibility(
+                ViewMatchers.Visibility.GONE)));
+        onView(withId(R.id.tvshows_label)).check(matches(withEffectiveVisibility(
+                ViewMatchers.Visibility.GONE)));
+    }
+
+    private Object[] reactionSentimentTypeValues() {
+        return new Object[] {
+            new Object[] {SentimentType.THUMBS_UP},
+            new Object[] {SentimentType.THUMBS_DOWN}
+        };
+    }
+
+    @Test
+    @Parameters(method = "reactionSentimentTypeValues")
+    public void assetListFragment_emptyList_displaysNoAssetLabel(SentimentType sentimentType) {
+        HiltFragmentScenario.launchHiltFragment(AssetListFragment.class,
+                createFragmentArgs(sentimentType));
+
+        onView(withId(R.id.no_assets_label)).check(matches(withText(R.string.noAssetLabel)));
+    }
+
+    @Test
+    public void assetListFragment_emptyUnspecifiedList_displaysNoUnspecifiedAssetLabel() {
+        HiltFragmentScenario.launchHiltFragment(AssetListFragment.class,
+                createFragmentArgs(SentimentType.UNSPECIFIED));
+
+        onView(withId(R.id.no_assets_label)).check(matches(withText(
+                R.string.noUnspecifiedAssetLabel)));
     }
 
     private Object[] displaysAssetsWithSentimentValues() {

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragment.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListFragment.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import com.google.moviestvsentiments.R;
@@ -48,6 +49,11 @@ public class AssetListFragment extends Fragment implements AssetListAdapter.Asse
         accountName = getActivity().getIntent().getStringExtra(SigninActivity.EXTRA_ACCOUNT_NAME);
         SentimentType sentimentType = AssetListFragmentArgs.fromBundle(getArguments())
                 .getSentimentType();
+
+        if (sentimentType == SentimentType.UNSPECIFIED) {
+            TextView noAssetsLabel = root.findViewById(R.id.no_assets_label);
+            noAssetsLabel.setText(R.string.noUnspecifiedAssetLabel);
+        }
 
         viewModel.getAssets(AssetType.MOVIE, accountName, sentimentType)
             .observe(getViewLifecycleOwner(), moviesResource -> {

--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListScreen.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/assetList/AssetListScreen.java
@@ -2,6 +2,7 @@ package com.google.moviestvsentiments.usecase.assetList;
 
 import android.content.Context;
 import android.view.View;
+import android.widget.TextView;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import com.google.moviestvsentiments.R;
@@ -15,6 +16,11 @@ public class AssetListScreen {
 
     private AssetListAdapter movieAdapter;
     private AssetListAdapter showAdapter;
+    private RecyclerView movieList;
+    private RecyclerView showList;
+    private TextView movieLabel;
+    private TextView showLabel;
+    private TextView noAssetsLabel;
 
     private AssetListScreen(AssetListAdapter.AssetClickListener assetClickListener) {
         movieAdapter = AssetListAdapter.create(assetClickListener);
@@ -37,12 +43,16 @@ public class AssetListScreen {
     }
 
     private void setupLists(View root, Context context) {
-        RecyclerView movieList = root.findViewById(R.id.movies_list);
+        noAssetsLabel = root.findViewById(R.id.no_assets_label);
+
+        movieLabel = root.findViewById(R.id.movies_label);
+        movieList = root.findViewById(R.id.movies_list);
         movieList.setAdapter(movieAdapter);
         movieList.setLayoutManager(new LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL,
                 false));
 
-        RecyclerView showList = root.findViewById(R.id.tvshows_list);
+        showLabel = root.findViewById(R.id.tvshows_label);
+        showList = root.findViewById(R.id.tvshows_list);
         showList.setAdapter(showAdapter);
         showList.setLayoutManager(new LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL,
                 false));
@@ -53,7 +63,7 @@ public class AssetListScreen {
      * @param movies The list of movies to display.
      */
     public void setMovies(List<AssetSentiment> movies) {
-        movieAdapter.setAssetSentiments(movies);
+        bind(movies, movieAdapter, movieList, movieLabel, showAdapter);
     }
 
     /**
@@ -61,6 +71,30 @@ public class AssetListScreen {
      * @param shows The list of TV shows to display.
      */
     public void setShows(List<AssetSentiment> shows) {
-        showAdapter.setAssetSentiments(shows);
+        bind(shows, showAdapter, showList, showLabel, movieAdapter);
+    }
+
+    /**
+     * Updates the user interface of the AssetListScreen for a new list of AssetSentiments.
+     * @param assetSentiments The new list of AssetSentiments that triggered the update.
+     * @param adapter The adapter that should display the list of AssetSentiments.
+     * @param list The RecyclerView that displays the adapter.
+     * @param label The label associated with the RecyclerView.
+     * @param otherAdapter The adapter associated with the list for the other type of Asset.
+     */
+    private void bind(List<AssetSentiment> assetSentiments, AssetListAdapter adapter,
+                      RecyclerView list, TextView label, AssetListAdapter otherAdapter) {
+        if (assetSentiments.isEmpty()) {
+            list.setVisibility(View.GONE);
+            label.setVisibility(View.GONE);
+            if (otherAdapter.getItemCount() == 0) {
+                noAssetsLabel.setVisibility(View.VISIBLE);
+            }
+        } else {
+            adapter.setAssetSentiments(assetSentiments);
+            list.setVisibility(View.VISIBLE);
+            label.setVisibility(View.VISIBLE);
+            noAssetsLabel.setVisibility(View.GONE);
+        }
     }
 }

--- a/MoviesTVSentiments/app/src/main/res/layouts/assetList/layout/asset_lists_screen.xml
+++ b/MoviesTVSentiments/app/src/main/res/layouts/assetList/layout/asset_lists_screen.xml
@@ -8,6 +8,22 @@
     tools:context=".usecase.assetList.AssetListFragment">
 
     <TextView
+        android:id="@+id/no_assets_label"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/bigPadding"
+        android:layout_marginStart="@dimen/bigPadding"
+        android:layout_marginEnd="@dimen/bigPadding"
+        android:textColor="@color/text"
+        android:textSize="@dimen/title_font_size"
+        android:text="@string/noAssetLabel"
+        android:textAlignment="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent" />
+
+    <TextView
         android:id="@+id/movies_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/MoviesTVSentiments/app/src/main/res/values/strings.xml
+++ b/MoviesTVSentiments/app/src/main/res/values/strings.xml
@@ -14,4 +14,6 @@
     <string name="signoutLabel">Sign Out</string>
     <string name="signinTitle">Sign In</string>
     <string name="offlineToast">Could not fetch data. Continuing in offline mode. Some results may be outdated.</string>
+    <string name="noAssetLabel">React to some movies or shows to see them on this screen.</string>
+    <string name="noUnspecifiedAssetLabel">Unable to fetch new movies and shows.</string>
 </resources>


### PR DESCRIPTION
Makes the following changes:
- If there are no shows or no movies for a sentiment type, hide the list and the corresponding label
- If both the show and movie lists are empty, display a message encouraging users to react to assets
- If both the show and movie lists are empty and the user is on the home screen, change the text of the message to say there are no new assets
- Adds tests for all of these cases


Movies present, but no TV shows:
<img width="346" alt="Screen Shot 2020-07-29 at 10 13 10 AM" src="https://user-images.githubusercontent.com/22841845/88821555-6d6f7580-d188-11ea-9790-3ce71a9780e3.png">

TV shows present, but no movies:
<img width="355" alt="Screen Shot 2020-07-29 at 10 12 32 AM" src="https://user-images.githubusercontent.com/22841845/88821629-8841ea00-d188-11ea-8478-a226bf00bdd8.png">

Neither movies nor TV shows present:
<img width="352" alt="Screen Shot 2020-07-29 at 10 12 47 AM" src="https://user-images.githubusercontent.com/22841845/88821680-955ed900-d188-11ea-8119-84c38ca1f962.png">

Neither movies nor TV shows present on the home screen:
<img width="360" alt="Screen Shot 2020-07-29 at 10 37 23 AM" src="https://user-images.githubusercontent.com/22841845/88821718-9f80d780-d188-11ea-8321-b5dd5eaad6f9.png">