### PR TITLE
Fix screen flicker bug

### DIFF
--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/navigation/SentimentsNavigationActivity.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/usecase/navigation/SentimentsNavigationActivity.java
@@ -47,6 +47,7 @@ public class SentimentsNavigationActivity extends AppCompatActivity implements
 
         viewModel.getCurrentAccount().observe(this, account -> {
             if (account == null) {
+                viewModel.getCurrentAccount().removeObservers(this);
                 Intent intent = new Intent(this, SigninActivity.class);
                 startActivity(intent);
                 finish();


### PR DESCRIPTION
The LiveData observer that triggers the transition back to the SigninActivity when a user clicks sign out was firing multiple times, causing the SigninActivity to flicker. I now remove the observer before going back to the SigninActivity, that way the flicker doesn't occur.