### PR TITLE
Fix asset list flicker bug

### DIFF
--- a/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDao.java
+++ b/MoviesTVSentiments/app/src/main/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentDao.java
@@ -11,7 +11,6 @@ import com.google.moviestvsentiments.model.AssetSentiment;
 import com.google.moviestvsentiments.model.AssetType;
 import com.google.moviestvsentiments.model.SentimentType;
 import com.google.moviestvsentiments.model.UserSentiment;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +24,13 @@ public abstract class AssetSentimentDao {
      */
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     public abstract void addAsset(Asset asset);
+
+    /**
+     * Adds the given list of assets into the assets table. Existing assets are ignored.
+     * @param assets The list of assets to insert.
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    public abstract void addAssets(List<Asset> assets);
 
     /**
      * Returns a LiveData view of the asset with the given id and type or null if the asset does not

--- a/MoviesTVSentiments/app/src/test-common/java/com/google/moviestvsentiments/util/UserSentimentListMatcher.java
+++ b/MoviesTVSentiments/app/src/test-common/java/com/google/moviestvsentiments/util/UserSentimentListMatcher.java
@@ -1,0 +1,47 @@
+package com.google.moviestvsentiments.util;
+
+import com.google.moviestvsentiments.model.UserSentiment;
+import org.mockito.ArgumentMatcher;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * An ArgumentMatcher that matches lists of UserSentiments.
+ */
+public class UserSentimentListMatcher implements ArgumentMatcher<List<UserSentiment>> {
+
+    private List<UserSentiment> lhs;
+
+    private UserSentimentListMatcher(List<UserSentiment> lhs) {
+        this.lhs = lhs;
+    }
+
+    /**
+     * Creates a new UserSentimentListMatcher that matches the given list of UserSentiments.
+     * @param sentiments The list of UserSentiments to match.
+     * @return A new UserSentimentListMatcher that matches the given list of UserSentiments.
+     */
+    public static UserSentimentListMatcher containsUserSentiments(UserSentiment ... sentiments) {
+        return new UserSentimentListMatcher(Arrays.asList(sentiments));
+    }
+
+    @Override
+    public boolean matches(List<UserSentiment> rhs) {
+        if (lhs.size() != rhs.size()) {
+            return false;
+        }
+
+        boolean result = true;
+        for (int i = 0; i < lhs.size() && result; i++) {
+            UserSentiment left = lhs.get(i);
+            UserSentiment right = rhs.get(i);
+            result = left.assetId.equals(right.assetId) &&
+                    left.accountName.equals(right.accountName) &&
+                    left.assetType == right.assetType &&
+                    left.sentimentType == right.sentimentType &&
+                    left.timestamp.equals(right.timestamp) &&
+                    left.isPending == right.isPending;
+        }
+        return result;
+    }
+}

--- a/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentRepositoryTest.java
+++ b/MoviesTVSentiments/app/src/test/java/com/google/moviestvsentiments/service/assetSentiment/AssetSentimentRepositoryTest.java
@@ -1,7 +1,9 @@
 package com.google.moviestvsentiments.service.assetSentiment;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.moviestvsentiments.util.UserSentimentListMatcher.containsUserSentiments;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -107,13 +109,13 @@ public class AssetSentimentRepositoryTest {
         when(webService.getAssets(AssetType.SHOW, ACCOUNT_NAME, SentimentType.UNSPECIFIED))
                 .thenReturn(remoteData);
 
-        Resource<List<AssetSentiment>> result = LiveDataTestUtil.getValue(
-                repository.getAssets(AssetType.SHOW, ACCOUNT_NAME, SentimentType.UNSPECIFIED));
+        LiveDataTestUtil.getValue(repository.getAssets(AssetType.SHOW, ACCOUNT_NAME,
+                SentimentType.UNSPECIFIED));
 
-        verify(dao, times(1)).addAsset(remoteSentiment.asset());
-        verify(dao, times(1)).updateSentiment(ACCOUNT_NAME,
-                remoteSentiment.asset().id(), AssetType.SHOW, SentimentType.UNSPECIFIED,
-                false, Instant.EPOCH);
+        verify(dao).addAssets(Arrays.asList(remoteSentiment.asset()));
+        verify(dao).updateSentiments(argThat(containsUserSentiments(UserSentiment.create(
+                remoteSentiment.asset().id(), ACCOUNT_NAME, AssetType.SHOW, SentimentType.UNSPECIFIED,
+                Instant.EPOCH, false))));
     }
 
     @Test


### PR DESCRIPTION
Fixes a bug where the asset list flickers when it first gets the list of assets from the server. This was the bug that you saw in the demo on Tuesday. The issue was that the repository was adding each asset and user sentiment into the Room database one at a time. This was causing the LiveData object to update over and over again, which was causing the asset list to continuously start loading new poster images, creating the flicker effect.